### PR TITLE
Catch collections not collection in CQL filters

### DIFF
--- a/sql/004_search.sql
+++ b/sql/004_search.sql
@@ -146,12 +146,12 @@ IF j ? 'id' THEN
     );
     newprops := jsonb_insert(newprops, '{1}', newprop);
 END IF;
-IF j ? 'collection' THEN
+IF j ? 'collections' THEN
     newprop := jsonb_build_object(
         'in',
         jsonb_build_array(
             '{"property":"collection"}'::jsonb,
-            j->'collection'
+            j->'collections'
         )
     );
     newprops := jsonb_insert(newprops, '{1}', newprop);
@@ -188,7 +188,7 @@ IF newprops IS NOT NULL AND jsonb_array_length(newprops) > 0 THEN
         j,
         '{filter}',
         cql_and_append(j, jsonb_build_object('and', newprops))
-    ) - '{id,collection,datetime,bbox,intersects}'::text[];
+    ) - '{id,collections,datetime,bbox,intersects}'::text[];
 END IF;
 
 return j;

--- a/test/pgtap/004_search.sql
+++ b/test/pgtap/004_search.sql
@@ -40,6 +40,23 @@ SELECT results_eq($$
     'Test that id gets added to cql filter when cql filter does exist'
 );
 
+SELECT results_eq($$
+    SELECT add_filters_to_cql('{"collections":["a","b"]}'::jsonb);
+    $$,$$
+    SELECT '{"filter":{"and": [{"in": [{"property": "collection"}, ["a", "b"]]}]}}'::jsonb;
+    $$,
+    'Test that collections gets added to cql filter when cql filter does not exist'
+);
+
+SELECT results_eq($$
+    SELECT add_filters_to_cql('{"collection":["a","b"]}'::jsonb);
+    $$,$$
+    SELECT '{"collection": ["a", "b"]}'::jsonb;
+    $$,
+    'Test that collection are not added to cql filter'
+);
+
+
 SELECT has_function('pgstac'::name, 'cql_and_append', ARRAY['jsonb','jsonb']);
 
 SELECT has_function('pgstac'::name, 'query_to_cqlfilter', ARRAY['jsonb']);

--- a/test/pgtap/004_search.sql
+++ b/test/pgtap/004_search.sql
@@ -140,7 +140,7 @@ SELECT results_eq($$
 SELECT results_eq($$
     select s from search('{"collections":["pgstac-test-collection"],"fields":{"include":["id"]}, "limit": 1}') s;
     $$,$$
-    select '{"next": 20200307aC0870130w361200, "prev": null, "type": "FeatureCollection", "context": {"limit": 1, "matched": 100, "returned": 1}, "features": [{"id": "20200307aC0870130w361200"}]}'::jsonb
+    select '{"next": "20200307aC0870130w361200", "prev": null, "type": "FeatureCollection", "context": {"limit": 1, "matched": 100, "returned": 1}, "features": [{"id": "20200307aC0870130w361200"}]}'::jsonb
     $$,
     'Test collections search with unknow collection'
 );

--- a/test/pgtap/004_search.sql
+++ b/test/pgtap/004_search.sql
@@ -140,7 +140,7 @@ SELECT results_eq($$
 SELECT results_eq($$
     select s from search('{"collections":["pgstac-test-collection"],"fields":{"include":["id"]}, "limit": 1}') s;
     $$,$$
-    select '{"next": null, "prev": null, "type": "FeatureCollection", "context": {"limit": 1, "matched": 100, "returned": 1}, "features": [{"id": "20200307aC0870130w361200"}]}'::jsonb
+    select '{"next": 20200307aC0870130w361200, "prev": null, "type": "FeatureCollection", "context": {"limit": 1, "matched": 100, "returned": 1}, "features": [{"id": "20200307aC0870130w361200"}]}'::jsonb
     $$,
     'Test collections search with unknow collection'
 );

--- a/test/pgtap/004_search.sql
+++ b/test/pgtap/004_search.sql
@@ -137,6 +137,22 @@ SELECT results_eq($$
     'Test lt as a filter on a numeric field with order by'
 );
 
+SELECT results_eq($$
+    select s from search('{"collections":["pgstac-test-collection"],"fields":{"include":["id"]}, "limit": 1}') s;
+    $$,$$
+    select '{"next": null, "prev": null, "type": "FeatureCollection", "context": {"limit": 1, "matched": 100, "returned": 1}, "features": [{"id": "20200307aC0870130w361200"}]}'::jsonb
+    $$,
+    'Test collections search with unknow collection'
+);
+
+SELECT results_eq($$
+    select s from search('{"collections":["something"]}') s;
+    $$,$$
+    select '{"next": null, "prev": null, "type": "FeatureCollection", "context": {"limit": 10, "matched": 0, "returned": 0}, "features": []}'::jsonb
+    $$,
+    'Test collections search with unknow collection'
+);
+
 /* template
 SELECT results_eq($$
 


### PR DESCRIPTION
This PR does:
- add tests for collections search 
- make sure `collections` and not `collection` get translated to CQL.

closes #42 