### PR TITLE
Add function which supports regular (non-ndjson) json file loading

### DIFF
--- a/pypgstac/tests/test_load.py
+++ b/pypgstac/tests/test_load.py
@@ -3,11 +3,13 @@ import asyncio
 from pathlib import Path
 import unittest
 
-from pypgstac.pypgstac import load_ndjson, loadopt, tables
+from pypgstac.pypgstac import loadopt, tables
+from pypgstac.load import load_json, load_ndjson
 
 HERE = Path(__file__).parent
 TEST_DATA_DIR = HERE.parent.parent / "test" / "testdata"
-TEST_COLLECTIONS = TEST_DATA_DIR / "collections.ndjson"
+TEST_COLLECTIONS_NDJSON = TEST_DATA_DIR / "collections.ndjson"
+TEST_COLLECTION_JSON = TEST_DATA_DIR / "collection.json"
 TEST_ITEMS = TEST_DATA_DIR / "items.ndjson"
 
 
@@ -18,7 +20,14 @@ class LoadTest(unittest.TestCase):
         """Test pypgstac data loader."""
         asyncio.run(
             load_ndjson(
-                str(TEST_COLLECTIONS),
+                str(TEST_COLLECTIONS_NDJSON),
+                table=tables.collections,
+                method=loadopt.upsert,
+            )
+        )
+        asyncio.run(
+            load_json(
+                str(TEST_COLLECTION_JSON),
                 table=tables.collections,
                 method=loadopt.upsert,
             )

--- a/test/testdata/collection.json
+++ b/test/testdata/collection.json
@@ -1,0 +1,50 @@
+{
+    "id": "pgstac-test-collection-json",
+    "stac_version": "1.0.0-beta.2",
+    "description": "The National Agriculture Imagery Program (NAIP) acquires aerial imagery\nduring the agricultural growing seasons in the continental U.S.\n\nNAIP projects are contracted each year based upon available funding and the\nFSA imagery acquisition cycle. Beginning in 2003, NAIP was acquired on\na 5-year cycle. 2008 was a transition year, and a three-year cycle began\nin 2009.\n\nNAIP imagery is acquired at a one-meter ground sample distance (GSD) with a\nhorizontal accuracy that matches within six meters of photo-identifiable\nground control points, which are used during image inspection.\n\nOlder images were collected using 3 bands (Red, Green, and Blue: RGB), but\nnewer imagery is usually collected with an additional near-infrared band\n(RGBN).",
+    "links": [
+      {
+        "rel": "root",
+        "href": "/collection.json",
+        "type": "application/json"
+      },
+      {
+        "rel": "self",
+        "href": "/collection.json",
+        "type": "application/json"
+      }
+    ],
+    "stac_extensions": [],
+    "title": "NAIP: National Agriculture Imagery Program",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -124.784,
+            24.744,
+            -66.951,
+            49.346
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2011-01-01T00:00:00Z",
+            "2019-01-01T00:00:00Z"
+          ]
+        ]
+      }
+    },
+    "license": "PDDL-1.0",
+    "providers": [
+      {
+        "name": "USDA Farm Service Agency",
+        "roles": [
+          "producer",
+          "licensor"
+        ],
+        "url": "https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/"
+      }
+    ]
+}


### PR DESCRIPTION
Because `ndjson` files treat `\n` characters semantically (as separators between bits of valid json), they must escape newlines found in the body of text fields a second time. Failing to supply the second escape causes errors within the `load_ndjson` method. Regular json files don't have this issue and will often include whitespace for the purposes of being human readable. In json (but not ndjson) files `orjson.load` has no difficulty distinguishing between newline characters in json text fields and those provided for the sake of whitespace in editors. This PR adds a function specifically for full-file JSON loading and removes two (apparently) unhelpful `replace` calls (if ndjson is not properly escaped it throws before the line in question can even be reached)