### PR TITLE
Added a command to bulk delete items included in an ndjson file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options:
 Commands:
   initversion  Get initial version.
   load         Load STAC data into a pgstac database.
+  deleteitems  Bulk delete items from the pgstac database.
   migrate      Migrate a pgstac database.
   pgready      Wait for a pgstac database to accept connections.
   version      Get version from a pgstac database.
@@ -126,6 +127,12 @@ pypgstac load items --method insert_ignore
 To upsert any records, adding anything new and replacing anything with the same id
 ```
 pypgstac load items --method upsert
+```
+
+Currently, upsert will fail if the `datetime` of an existing record is updated. To work around this issue, you can bulk delete items prior to loading them
+
+```
+pypgstac deleteitems
 ```
 
 ## Contribution & Development

--- a/pypgstac/pypgstac/pypgstac.py
+++ b/pypgstac/pypgstac/pypgstac.py
@@ -7,7 +7,8 @@ import asyncpg
 import typer
 
 from .migrate import run_migration, get_version_dsn, get_initial_version
-from .load import loadopt, tables, load_ndjson
+from .load import delete_ndjson, loadopt, tables, load_ndjson
+
 
 app = typer.Typer()
 
@@ -41,6 +42,12 @@ def load(
 ) -> None:
     """Load STAC data into a pgstac database."""
     typer.echo(asyncio.run(load_ndjson(file=file, table=table, dsn=dsn, method=method)))
+
+
+@app.command()
+def deleteitems(file: str, dsn: str = None) -> None:
+    """Bulk delete STAC Items matching IDs in an NDJSON file."""
+    typer.echo(asyncio.run(delete_ndjson(file=file, dsn=dsn)))
 
 
 @app.command()

--- a/pypgstac/pyproject.toml
+++ b/pypgstac/pyproject.toml
@@ -12,7 +12,7 @@ include = ["pypgstac/migrations/pgstac*.sql"]
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-smart-open = "^4.2.0"
+smart-open = "^6.0.0"
 typer = ">=0.4.0"
 orjson = ">=3.5.2"
 python-dateutil = "^2.8.2"

--- a/pypgstac/tests/test_load.py
+++ b/pypgstac/tests/test_load.py
@@ -3,12 +3,19 @@ import asyncio
 from pathlib import Path
 import unittest
 
-from pypgstac.pypgstac import load_ndjson, loadopt, tables
+from pypgstac.pypgstac import delete_ndjson, load_ndjson, loadopt, tables
+from pypgstac.load import DB
 
 HERE = Path(__file__).parent
 TEST_DATA_DIR = HERE.parent.parent / "test" / "testdata"
 TEST_COLLECTIONS = TEST_DATA_DIR / "collections.ndjson"
 TEST_ITEMS = TEST_DATA_DIR / "items.ndjson"
+
+
+async def count_items() -> int:
+    async with DB() as conn:
+        row = await conn.fetchrow("SELECT COUNT(*) FROM items")
+        return row[0]
 
 
 class LoadTest(unittest.TestCase):
@@ -26,3 +33,14 @@ class LoadTest(unittest.TestCase):
         asyncio.run(
             load_ndjson(str(TEST_ITEMS), table=tables.items, method=loadopt.upsert)
         )
+
+    def test_delete_succeeds(self) -> None:
+        """Test bulk delete items"""
+        starting_item_count = asyncio.run(count_items())
+        # Load some items in case there aren't any in the DB yet.
+        asyncio.run(
+            load_ndjson(str(TEST_ITEMS), table=tables.items, method=loadopt.upsert)
+        )
+        loaded_item_count = asyncio.run(count_items())
+        asyncio.run(delete_ndjson(str(TEST_ITEMS)))
+        assert asyncio.run(count_items()) == starting_item_count - loaded_item_count

--- a/pypgstac/tests/test_load.py
+++ b/pypgstac/tests/test_load.py
@@ -1,7 +1,11 @@
 """Tests for pypgstac."""
 import asyncio
+from copy import copy
+import json
 from pathlib import Path
+from typing import IO
 import unittest
+from tempfile import NamedTemporaryFile
 
 from pypgstac.pypgstac import delete_ndjson, load_ndjson, loadopt, tables
 from pypgstac.load import DB
@@ -11,11 +15,29 @@ TEST_DATA_DIR = HERE.parent.parent / "test" / "testdata"
 TEST_COLLECTIONS = TEST_DATA_DIR / "collections.ndjson"
 TEST_ITEMS = TEST_DATA_DIR / "items.ndjson"
 
+with open(TEST_DATA_DIR / "sample_item.json", "r") as f:
+    SAMPLE_ITEM = json.load(f)
+
 
 async def count_items() -> int:
     async with DB() as conn:
         row = await conn.fetchrow("SELECT COUNT(*) FROM items")
         return row[0]
+
+
+async def clear_items() -> None:
+    async with DB() as conn:
+        await conn.fetchrow("DELETE FROM items")
+
+
+def create_ndjson_file(num_items: int = 1000) -> IO[bytes]:
+    f = NamedTemporaryFile()
+    for i in range(num_items + 1):
+        item = copy(SAMPLE_ITEM)
+        item["id"] = f"pgstac-test-item-{i}"
+        f.write(str.encode(f"{json.dumps(item)}\n"))
+    f.seek(0)
+    return f
 
 
 class LoadTest(unittest.TestCase):
@@ -36,11 +58,25 @@ class LoadTest(unittest.TestCase):
 
     def test_delete_succeeds(self) -> None:
         """Test bulk delete items"""
-        starting_item_count = asyncio.run(count_items())
+        asyncio.run(clear_items())
         # Load some items in case there aren't any in the DB yet.
         asyncio.run(
             load_ndjson(str(TEST_ITEMS), table=tables.items, method=loadopt.upsert)
         )
-        loaded_item_count = asyncio.run(count_items())
+        self.assertGreater(asyncio.run(count_items()), 0)
         asyncio.run(delete_ndjson(str(TEST_ITEMS)))
-        assert asyncio.run(count_items()) == starting_item_count - loaded_item_count
+        self.assertEqual(asyncio.run(count_items()), 0)
+
+    def test_delete_high_volume(self) -> None:
+        """Bulk deleting a large quantity of items succeeds"""
+        asyncio.run(clear_items())
+        # Load many items to delete
+        ndjson_file = create_ndjson_file(10000)
+        asyncio.run(
+            load_ndjson(ndjson_file.name, table=tables.items, method=loadopt.upsert)
+        )
+        self.assertGreater(asyncio.run(count_items()), 0)
+        ndjson_file.seek(0)
+        asyncio.run(delete_ndjson(ndjson_file.name))
+        ndjson_file.close()
+        self.assertEqual(asyncio.run(count_items()), 0)

--- a/test/testdata/sample_item.json
+++ b/test/testdata/sample_item.json
@@ -1,0 +1,128 @@
+{
+    "id": "pgstac-test-item-0100",
+    "bbox": [
+        -87.816179,
+        30.496894,
+        -87.74637,
+        30.565604
+    ],
+    "type": "Feature",
+    "links": [],
+    "assets": {
+        "image": {
+            "href": "https://naipeuwest.blob.core.windows.net/naip/v002/al/2011/al_100cm_2011/30087/m_3008726_se_16_1_20110731.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ],
+            "title": "RGBIR COG tile",
+            "eo:bands": [
+                {
+                    "name": "Red",
+                    "common_name": "red"
+                },
+                {
+                    "name": "Green",
+                    "common_name": "green"
+                },
+                {
+                    "name": "Blue",
+                    "common_name": "blue"
+                },
+                {
+                    "name": "NIR",
+                    "common_name": "nir",
+                    "description": "near-infrared"
+                }
+            ]
+        },
+        "metadata": {
+            "href": "https://naipeuwest.blob.core.windows.net/naip/v002/al/2011/al_fgdc_2011/30087/m_3008726_se_16_1_20110731.txt",
+            "type": "text/plain",
+            "roles": [
+                "metadata"
+            ],
+            "title": "FGDC Metdata"
+        },
+        "thumbnail": {
+            "href": "https://naipeuwest.blob.core.windows.net/naip/v002/al/2011/al_100cm_2011/30087/m_3008726_se_16_1_20110731.200.jpg",
+            "type": "image/jpeg",
+            "roles": [
+                "thumbnail"
+            ],
+            "title": "Thumbnail"
+        }
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -87.74637,
+                    30.497308
+                ],
+                [
+                    -87.746892,
+                    30.565604
+                ],
+                [
+                    -87.816179,
+                    30.565188
+                ],
+                [
+                    -87.815608,
+                    30.496894
+                ],
+                [
+                    -87.74637,
+                    30.497308
+                ]
+            ]
+        ]
+    },
+    "collection": "pgstac-test-collection",
+    "properties": {
+        "gsd": 1,
+        "datetime": "2011-07-31T00:00:00Z",
+        "naip:year": "2011",
+        "proj:bbox": [
+            421730,
+            3374130,
+            428375,
+            3381699
+        ],
+        "proj:epsg": 26916,
+        "providers": [
+            {
+                "url": "https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/",
+                "name": "USDA Farm Service Agency",
+                "roles": [
+                    "producer",
+                    "licensor"
+                ]
+            }
+        ],
+        "naip:state": "al",
+        "proj:shape": [
+            7569,
+            6645
+        ],
+        "eo:cloud_cover": 50,
+        "proj:transform": [
+            1,
+            0,
+            421730,
+            0,
+            -1,
+            3381699,
+            0,
+            0,
+            1
+        ]
+    },
+    "stac_version": "1.0.0-beta.2",
+    "stac_extensions": [
+        "eo",
+        "projection"
+    ]
+}


### PR DESCRIPTION
# Background

Given that uniqueness constraints on the `items` table combine `id` and `datetime`, loading data with the `upsert` method will fail if the `datetime` for an existing row has changed (but the `id` is the same, of course).

*I don't have a solution to this issue*, but I do have a workaround, which is to bulk delete items prior to loading them. This isn't the most efficient solution, but it will work for my use case. I'm 100% open to alternative approaches and wanted to open this PR to seek feedback.

# Approach

I've added a new `deleteitems` command, which takes an NDJSON file and deletes items from the DB matching the `id`s of each row in the file. The idea is to use the same input file to bulk delete and then insert data.

# Concerns

Aside from the inefficiency of this approach, I wonder if providing an NDJSON file of complete STAC items while deleting based solely on the `id` could confuse users.
