### PR TITLE
Add autocommit to connections

### DIFF
--- a/pypgstac/pypgstac/db.py
+++ b/pypgstac/pypgstac/db.py
@@ -103,6 +103,7 @@ class PgstacDB:
         pool = self.get_pool()
         if self.connection is None:
             self.connection = pool.getconn()
+            self.connection.autocommit = True
             if self.debug:
                 self.connection.add_notice_handler(pg_notice_handler)
             atexit.register(self.disconnect)

--- a/pypgstac/pypgstac/db.py
+++ b/pypgstac/pypgstac/db.py
@@ -12,6 +12,8 @@ import logging
 from pydantic import BaseSettings
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
+logger = logging.getLogger(__name__)
+
 
 def dumps(data: dict) -> str:
     """Dump dictionary as string."""
@@ -25,7 +27,7 @@ set_json_loads(orjson.loads)
 def pg_notice_handler(notice: psycopg.errors.Diagnostic) -> None:
     """Add PG messages to logging."""
     msg = f"{notice.severity} - {notice.message_primary}"
-    logging.info(msg)
+    logger.info(msg)
 
 
 class Settings(BaseSettings):
@@ -180,7 +182,7 @@ class PgstacDB:
                         yield row
         except psycopg.errors.OperationalError as e:
             # If we get an operational error check the pool and retry
-            logging.warning(f"OPERATIONAL ERROR: {e}")
+            logger.warning(f"OPERATIONAL ERROR: {e}")
             if self.pool is None:
                 self.get_pool()
             else:
@@ -214,13 +216,13 @@ class PgstacDB:
                 order by datetime desc, version desc limit 1;
                 """
             )
-            logging.debug(f"VERSION: {version}")
+            logger.debug(f"VERSION: {version}")
             if isinstance(version, bytes):
                 version = version.decode()
             if isinstance(version, str):
                 return version
         except psycopg.errors.UndefinedTable:
-            logging.debug("PGStac is not installed.")
+            logger.debug("PGStac is not installed.")
             if self.connection is not None:
                 self.connection.rollback()
         return None
@@ -233,7 +235,7 @@ class PgstacDB:
             SHOW server_version;
             """
         )
-        logging.debug(f"PG VERSION: {version}.")
+        logger.debug(f"PG VERSION: {version}.")
         if isinstance(version, bytes):
             version = version.decode()
         if isinstance(version, str):

--- a/pypgstac/pypgstac/load.py
+++ b/pypgstac/pypgstac/load.py
@@ -108,9 +108,7 @@ def read_json(file: Union[Path, str, Iterator[Any]] = "stdin") -> Iterable:
                     yield orjson.loads(line)
             except JSONDecodeError:
                 # If reading first line as json fails, try reading entire file
-                logger.info(
-                    "First line could not be parsed as json, trying full file."
-                )
+                logger.info("First line could not be parsed as json, trying full file.")
                 try:
                     f.seek(0)
                     json = orjson.loads(f.read())
@@ -427,9 +425,7 @@ class Loader:
         for k, g in itertools.groupby(items, lambda x: x["partition"]):
             self.load_partition(partitions[k], g, insert_mode)
 
-        logger.debug(
-            f"Adding data to database took {time.perf_counter() - t} seconds."
-        )
+        logger.debug(f"Adding data to database took {time.perf_counter() - t} seconds.")
 
     def format_item(self, _item: Union[Path, str, dict]) -> dict:
         """Format an item to insert into a record."""

--- a/pypgstac/pypgstac/migrate.py
+++ b/pypgstac/pypgstac/migrate.py
@@ -12,6 +12,8 @@ from . import __version__
 dirname = os.path.dirname(__file__)
 migrations_dir = os.path.join(dirname, "migrations")
 
+logger = logging.getLogger(__name__)
+
 
 class MigrationPath:
     """Calculate path from migration files to get from one version to the next."""
@@ -115,16 +117,16 @@ class Migrate:
         files = []
 
         pg_version = self.db.pg_version
-        logging.info(f"Migrating PGStac on PostgreSQL Version {pg_version}")
+        logger.info(f"Migrating PGStac on PostgreSQL Version {pg_version}")
         oldversion = self.db.version
         if oldversion == toversion:
-            logging.info(f"Target database already at version: {toversion}")
+            logger.info(f"Target database already at version: {toversion}")
             return toversion
         if oldversion is None:
-            logging.info(f"No pgstac version set, installing {toversion} from scratch.")
+            logger.info(f"No pgstac version set, installing {toversion} from scratch.")
             files.append(os.path.join(migrations_dir, f"pgstac.{toversion}.sql"))
         else:
-            logging.info(f"Migrating from {oldversion} to {toversion}.")
+            logger.info(f"Migrating from {oldversion} to {toversion}.")
             m = MigrationPath(migrations_dir, oldversion, toversion)
             files = m.migrations()
 
@@ -135,13 +137,13 @@ class Migrate:
 
         with conn.cursor() as cur:
             for file in files:
-                logging.debug(f"Running migration file {file}.")
+                logger.debug(f"Running migration file {file}.")
                 migration_sql = get_sql(file)
                 cur.execute(migration_sql)
-                logging.debug(cur.statusmessage)
-                logging.debug(cur.rowcount)
+                logger.debug(cur.statusmessage)
+                logger.debug(cur.rowcount)
 
-            logging.debug(f"Database migrated to {toversion}")
+            logger.debug(f"Database migrated to {toversion}")
 
         newversion = self.db.version
         if conn is not None:
@@ -153,6 +155,6 @@ class Migrate:
                     "Migration failed, database rolled back to previous state."
                 )
 
-        logging.debug(f"New Version: {newversion}")
+        logger.debug(f"New Version: {newversion}")
 
         return newversion


### PR DESCRIPTION
This PR adds `.autocommit = True` to new connections from `PgstacDB`. 

I ran into an issue where long, multi-load ingests were holding locks for the duration of the entire ingest. There was a transaction was open the entire time the connection was open, and so the partition being ingested into was lockd the entire ingest. Using autocommit scoped the lock issues to a single scoped call to `load_items`.

Based on the [Hint at the bottom of these docs](https://www.psycopg.org/psycopg3/docs/basic/transactions.html?msclkid=496fe3b1d0d511eca8f7aae193c127a1#transaction-contexts), `autocommit` on the connections that are established in PgstacDB to avoid any transaction issues.

In addition, a scoped `logger` is used so that it's possible for client code to adjust logging levels of pypgstac directly, e.g. turn on debug logging just for the package.