### PR TITLE
Ensure special keys are not in content when loaded

### DIFF
--- a/pypgstac/pypgstac/load.py
+++ b/pypgstac/pypgstac/load.py
@@ -544,9 +544,8 @@ class Loader:
 
         out["partition"] = partition
 
-        bbox = item.get("bbox")
         geojson = item.get("geometry")
-        if geojson is None and bbox is not None:
+        if geojson is None:
             geometry = None
         else:
             geometry = str(Geometry.from_geojson(geojson).wkb)

--- a/pypgstac/pypgstac/load.py
+++ b/pypgstac/pypgstac/load.py
@@ -511,8 +511,8 @@ class Loader:
 
         base_item, key, partition_trunc = self.collection_json(item["collection"])
 
-        out["id"] = item.pop("id")
-        out["collection"] = item.pop("collection")
+        out["id"] = item.get("id")
+        out["collection"] = item.get("collection")
         properties: dict = item.get("properties", {})
 
         dt = properties.get("datetime")
@@ -544,8 +544,8 @@ class Loader:
 
         out["partition"] = partition
 
-        bbox = item.pop("bbox")
-        geojson = item.pop("geometry")
+        bbox = item.get("bbox")
+        geojson = item.get("geometry")
         if geojson is None and bbox is not None:
             geometry = None
         else:
@@ -553,6 +553,12 @@ class Loader:
         out["geometry"] = geometry
 
         content = dehydrate(base_item, item)
+
+        # Remove keys from the dehydrated item content which are stored directly
+        # on the table row.
+        content.pop("id", None)
+        content.pop("collection", None)
+        content.pop("geometry", None)
 
         out["content"] = orjson.dumps(content).decode()
 


### PR DESCRIPTION
The loader pop'd keys like `collection` off the item, then dehydrated the
item to be used as the 'content'. With `collection` removed prior to
dehydration, it was flagged with the "do-not-merge" marker because the
key is on the base_item. Instead, ensure that id, collection, and
geometry are not in `content` as they are stored on the table row and
shouldn't participate in hydration.

Additionally, bbox was previously a derived value at search runtime but
was recently changed to a returned value if it existed on the item.
However, during loading, the bbox was dropped so would never exist on
the persisted item.