### PR TITLE
Avoid updating partitions table when unnecessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Skip partition updates when unnecessary, which can drastically improve large ingest performance into existing partitions. [#114](https://github.com/stac-utils/pgstac/pull/114)
+
 ## [v0.6.2]
 
 ### Fixed

--- a/pypgstac/pypgstac/db.py
+++ b/pypgstac/pypgstac/db.py
@@ -165,7 +165,7 @@ class PgstacDB:
     def query(
         self,
         query: Union[str, sql.Composed],
-        args: Optional[List] = None,
+        args: Optional[List[Any]] = None,
         row_factory: psycopg.rows.BaseRowFactory = psycopg.rows.tuple_row,
     ) -> Generator:
         """Query the database with parameters."""


### PR DESCRIPTION
This commit refactors the loader code to avoid unnecessary partition updates. Partition updates should be avoided when unnecessary as they can have a large performance impact for partitions containing many items.
