### PR TITLE
Loader optimization: Fix incorrect in-place sort of chunks by partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed issue loader grouping an unordered iterable by partition, speeding up loads of items with mixed partitions [#116](https://github.com/stac-utils/pgstac/pull/116)
+
 ## [v0.6.3]
 
 ### Fixed

--- a/pypgstac/pypgstac/load.py
+++ b/pypgstac/pypgstac/load.py
@@ -552,7 +552,8 @@ class Loader:
             items = self.read_hydrated(file)
 
         for chunk in chunked_iterable(items, chunksize):
-            list(chunk).sort(key=lambda x: x["partition"])
+            chunk = list(chunk)
+            chunk.sort(key=lambda x: x["partition"])
             for k, g in itertools.groupby(chunk, lambda x: x["partition"]):
                 self.load_partition(self._partition_cache[k], g, insert_mode)
 


### PR DESCRIPTION
In-place sort was being done on an ephemeral list. The lack of sort was causing itertools.group_by to make small groups as it streamed through the iterator, causing ingests to be slow for large sets of items with a mix of partitions. 

Seeing a significant performance increase for large item ingest with many partitions (weekly partitions on about 4 months of Sentinel 2, dropping 50K item group ingests from 1000s to 40s)