### PR TITLE
Correct insert_mode check

### DIFF
--- a/pypgstac/pypgstac/load.py
+++ b/pypgstac/pypgstac/load.py
@@ -325,7 +325,7 @@ class Loader:
                     logger.debug(cur.statusmessage)
                     logger.debug(f"Rows affected: {cur.rowcount}")
                 elif insert_mode in (
-                    "ignore_dupes",
+                    "insert_ignore",
                     "upsert",
                     "delsert",
                     "ignore",


### PR DESCRIPTION
I don't believe that `"ignore_dupes"` is a proper `insert_mode` value (it is not present in the `InsertMethods` enum):

https://github.com/stac-utils/pgstac/blob/e72a17ca33e552e417a8863bdd4289f9fd4db030/pypgstac/pypgstac/load.py#L74-L81

@bitner 