### PR TITLE
update pinned versions of several dependencies

### DIFF
--- a/pypgstac/setup.py
+++ b/pypgstac/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "smart-open==6.2.*",
+    "smart-open>=4.2,<7.0",
     "orjson>=3.5.2",
     "python-dateutil==2.8.*",
     "fire==0.4.*",

--- a/pypgstac/setup.py
+++ b/pypgstac/setup.py
@@ -6,13 +6,13 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "smart-open==4.2.*",
+    "smart-open==6.2.*",
     "orjson>=3.5.2",
     "python-dateutil==2.8.*",
     "fire==0.4.*",
     "plpygis==0.2.*",
-    "pydantic[dotenv]==1.9.*",
-    "tenacity==8.0.*",
+    "pydantic[dotenv]==1.10.*",
+    "tenacity==8.1.*",
 ]
 
 extra_reqs = {
@@ -25,7 +25,7 @@ extra_reqs = {
         "pystac[validation]==1.*"
     ],
     "psycopg": [
-        "psycopg[binary]==3.0.*",
+        "psycopg[binary]==3.1.*",
         "psycopg-pool==3.1.*",
     ],
 }


### PR DESCRIPTION
I am working on incorporating `pgstac` into a project and I had to downgrade to smart-open==4.2.0 so I thought I would try bumping the pinned version to the latest (6.2.*). Since I was in there already I bumped a few other less-outdated pinned versions, too. All of the tests are passing when I run `scripts/test` as described in the contributing guidelines!

Maybe there is a good reason smart-open is held back to version 4.2.* but in case there is not one, here is a PR!