### PR TITLE
Allow empty strings in datetime intervals

### DIFF
--- a/sql/002b_cql.sql
+++ b/sql/002b_cql.sql
@@ -34,13 +34,13 @@ BEGIN
         RAISE EXCEPTION 'Timestamp cannot have more than 2 values';
     END IF;
 
-    IF timestrs[1] = '..' THEN
+    IF timestrs[1] = '..' OR timestrs[1] = '' THEN
         s := '-infinity'::timestamptz;
         e := timestrs[2]::timestamptz;
         RETURN tstzrange(s,e,'[)');
     END IF;
 
-    IF timestrs[2] = '..' THEN
+    IF timestrs[2] = '..' OR timestrs[2] = '' THEN
         s := timestrs[1]::timestamptz;
         e := 'infinity'::timestamptz;
         RETURN tstzrange(s,e,'[)');

--- a/test/pgtap/004_search.sql
+++ b/test/pgtap/004_search.sql
@@ -14,6 +14,18 @@ SELECT results_eq($$ SELECT parse_dtrange('["2020-01-01","2021-01-01"]'::jsonb) 
 SELECT results_eq($$ SELECT parse_dtrange('"2020-01-01/2021-01-01"'::jsonb) $$, $$ SELECT '["2020-01-01 00:00:00+00","2021-01-01 00:00:00+00")'::tstzrange $$, 'date range passed as string range');
 
 
+SELECT results_eq($$ SELECT parse_dtrange('"2020-01-01/.."'::jsonb) $$, $$ SELECT '["2020-01-01 00:00:00+00",infinity)'::tstzrange $$, 'date range passed as string range');
+
+
+SELECT results_eq($$ SELECT parse_dtrange('"2020-01-01/"'::jsonb) $$, $$ SELECT '["2020-01-01 00:00:00+00",infinity)'::tstzrange $$, 'date range passed as string range');
+
+
+SELECT results_eq($$ SELECT parse_dtrange('"../2020-01-01"'::jsonb) $$, $$ SELECT '[-infinity,"2020-01-01 00:00:00+00")'::tstzrange $$, 'date range passed as string range');
+
+
+SELECT results_eq($$ SELECT parse_dtrange('"/2020-01-01"'::jsonb) $$, $$ SELECT '[-infinity,"2020-01-01 00:00:00+00")'::tstzrange $$, 'date range passed as string range');
+
+
 SELECT has_function('pgstac'::name, 'bbox_geom', ARRAY['jsonb']);
 
 


### PR DESCRIPTION
## Related issues

- Prompted by https://github.com/stac-utils/stac-fastapi/issues/464

## Description

Adds support for empty strings in datetime intervals, e.g. `2023-02-02/`. Includes tests.

I'm opening this as a draft PR b/c I'm not sure of the correct process to propogate these changes to the actual files that get run (e.g.) when you do `scripts/test`. To test locally, I made a new version w/ my modifications. Does every PR get a new version?