### PR TITLE
Use library for version parsing

### DIFF
--- a/src/pypgstac/pypgstac/load.py
+++ b/src/pypgstac/pypgstac/load.py
@@ -25,7 +25,6 @@ import orjson
 import psycopg
 from cachetools.func import lru_cache
 from orjson import JSONDecodeError
-from pkg_resources import parse_version as V
 from plpygis.geometry import Geometry
 from psycopg import sql
 from psycopg.types.range import Range
@@ -36,6 +35,7 @@ from tenacity import (
     stop_after_attempt,
     wait_random_exponential,
 )
+from version_parser import Version as V
 
 from .db import PgstacDB
 from .hydration import dehydrate
@@ -162,9 +162,9 @@ class Loader:
 
         v1 = V(db_version)
         v2 = V(__version__)
-        if (v1.major, v1.minor) != (
-            v2.major,
-            v2.minor,
+        if (v1.get_major_version(), v1.get_minor_version()) != (
+            v2.get_major_version(),
+            v2.get_minor_version(),
         ):
             raise Exception(
                 f"pypgstac version {__version__}"
@@ -305,7 +305,6 @@ class Loader:
                 logger.debug(f"Partition {partition.name} does not require an update.")
 
             with conn.transaction():
-
 
                 t = time.perf_counter()
                 if insert_mode in (

--- a/src/pypgstac/pyproject.toml
+++ b/src/pypgstac/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic[dotenv]==1.10.*",
     "tenacity==8.1.*",
     "cachetools==5.3.*",
+    "version-parser>= 1.0.1",
 ]
 
 [project.optional-dependencies]

--- a/src/pypgstac/setup.py
+++ b/src/pypgstac/setup.py
@@ -31,5 +31,6 @@ setup(
         "plpygis==0.2.*",
         "pydantic[dotenv]==1.10.*",
         "tenacity==8.1.*",
+        "version-parser>= 1.0.1",
     ],
 )

--- a/src/pypgstac/tests/test_load.py
+++ b/src/pypgstac/tests/test_load.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pystac
 import pytest
-from pkg_resources import parse_version as V
 from psycopg.errors import UniqueViolation
+from version_parser import Version as V
 
 from pypgstac.load import Loader, Methods, __version__, read_json
 
@@ -30,9 +30,20 @@ S1_GRD_ITEM = (
     / "S1A_IW_GRDH_1SDV_20220428T034417_20220428T034442_042968_05213C.json"
 )
 
+
 def version_increment(source_version: str) -> str:
     version = V(source_version)
-    return ".".join(map(str, [version.major, version.minor, version.micro + 1]))
+    return ".".join(
+        map(
+            str,
+            [
+                version.get_major_version(),
+                version.get_minor_version(),
+                version.get_patch_version() + 1,
+            ],
+        ),
+    )
+
 
 def test_load_collections_succeeds(loader: Loader) -> None:
     """Test pypgstac collections loader."""


### PR DESCRIPTION
The [previous library](https://setuptools.pypa.io/en/latest/pkg_resources.html) for parsing a version string relied on a particular version of setuptools (>=59) that wasn't a direct dependency of the project. As a result, different python environments would fail during loading. Switching to a library that can be pinned, a mostly drop-in replacement.

Existing version compatibility tests pass.