### PR TITLE
fix: return '[]' instead of NULL from all_collections when the table is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Return an empty jsonb array from all_collections() when the collections table is empty, instead of NULL. Fixes #186.
+
 ## [v0.7.9]
 
 ### Fixed

--- a/src/pgstac/sql/002_collections.sql
+++ b/src/pgstac/sql/002_collections.sql
@@ -63,5 +63,5 @@ $$ LANGUAGE SQL SET SEARCH_PATH TO pgstac,public;
 
 
 CREATE OR REPLACE FUNCTION all_collections() RETURNS jsonb AS $$
-    SELECT jsonb_agg(content) FROM collections;
+    SELECT coalesce(jsonb_agg(content), '[]'::jsonb) FROM collections;
 $$ LANGUAGE SQL SET SEARCH_PATH TO pgstac,public;

--- a/src/pgstac/tests/pgtap/002a_queryables.sql
+++ b/src/pgstac/tests/pgtap/002a_queryables.sql
@@ -21,6 +21,13 @@ SELECT results_eq(
 );
 
 DELETE FROM collections WHERE id in ('pgstac-test-collection', 'pgstac-test-collection2');
+
+SELECT results_eq(
+    $$ SELECT all_collections(); $$,
+    $$ SELECT '[]'::jsonb; $$,
+    'Make sure all_collections returns an empty array when the collection table is empty.'
+);
+
 \copy collections (content) FROM 'tests/testdata/collections.ndjson';
 
 SELECT results_eq(


### PR DESCRIPTION
fixes #186 

test fails before:
![image](https://github.com/stac-utils/pgstac/assets/42875462/69994df1-54d2-48e6-8484-15eff52cb129)

test passes after:
![image](https://github.com/stac-utils/pgstac/assets/42875462/ffbda441-2f3f-4fb5-84bc-02b9076fb0ed)
