### PR TITLE
Remove default eo:cloud_cover queryable

### DIFF
--- a/docs/src/pgstac.md
+++ b/docs/src/pgstac.md
@@ -98,7 +98,7 @@ In general, you should aim to keep each partition less than a few hundred thousa
 
 #### PGStac Indexes / Queryables
 
-By default, PGStac includes indexes on the id, datetime, collection, geometry, and the eo:cloud_cover property. Further indexing can be added for additional properties globally or only on particular collections by modifications to the queryables table.
+By default, PGStac includes indexes on the id, datetime, collection, and geometry. Further indexing can be added for additional properties globally or only on particular collections by modifications to the queryables table.
 
 The `queryables` table controls the indexes that PGStac will build as well as the metadata that is returned from a [STAC Queryables endpoint](https://github.com/stac-api-extensions/filter#queryables).
 

--- a/src/pgstac/migrations/pgstac.0.7.10-unreleased.sql
+++ b/src/pgstac/migrations/pgstac.0.7.10-unreleased.sql
@@ -286,15 +286,6 @@ DO $$
   END
 $$;
 
-DO $$
-  BEGIN
-    INSERT INTO queryables (name, definition, property_wrapper, property_index_type) VALUES
-    ('eo:cloud_cover','{"$ref": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#/definitions/fieldsproperties/eo:cloud_cover"}','to_int','BTREE');
-  EXCEPTION WHEN unique_violation THEN
-    RAISE NOTICE '%', SQLERRM USING ERRCODE = SQLSTATE;
-  END
-$$;
-
 DELETE FROM queryables a USING queryables b
   WHERE a.name = b.name AND a.collection_ids IS NOT DISTINCT FROM b.collection_ids AND a.id > b.id;
 

--- a/src/pgstac/migrations/pgstac.unreleased.sql
+++ b/src/pgstac/migrations/pgstac.unreleased.sql
@@ -4069,15 +4069,6 @@ DO $$
   END
 $$;
 
-DO $$
-  BEGIN
-    INSERT INTO queryables (name, definition, property_wrapper, property_index_type) VALUES
-    ('eo:cloud_cover','{"$ref": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#/definitions/fieldsproperties/eo:cloud_cover"}','to_int','BTREE');
-  EXCEPTION WHEN unique_violation THEN
-    RAISE NOTICE '%', SQLERRM USING ERRCODE = SQLSTATE;
-  END
-$$;
-
 DELETE FROM queryables a USING queryables b
   WHERE a.name = b.name AND a.collection_ids IS NOT DISTINCT FROM b.collection_ids AND a.id > b.id;
 

--- a/src/pgstac/sql/998_idempotent_post.sql
+++ b/src/pgstac/sql/998_idempotent_post.sql
@@ -25,15 +25,6 @@ DO $$
   END
 $$;
 
-DO $$
-  BEGIN
-    INSERT INTO queryables (name, definition, property_wrapper, property_index_type) VALUES
-    ('eo:cloud_cover','{"$ref": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#/definitions/fieldsproperties/eo:cloud_cover"}','to_int','BTREE');
-  EXCEPTION WHEN unique_violation THEN
-    RAISE NOTICE '%', SQLERRM USING ERRCODE = SQLSTATE;
-  END
-$$;
-
 DELETE FROM queryables a USING queryables b
   WHERE a.name = b.name AND a.collection_ids IS NOT DISTINCT FROM b.collection_ids AND a.id > b.id;
 


### PR DESCRIPTION
This default queryable was added in the early days of pgstac so that the field would be indexed by default if it was present in any items. However, now that the queryables table is used to generate content for `/queryables` stac endpoint in stac-fastapi, it is included in the queryable content for all collections (since there is no `collection_id`).

Removing this optimization fixes incorrect (and broken, since the $ref URL also has a typo) default behavior.