### PR TITLE
Add partition_update_enabled option

### DIFF
--- a/src/pypgstac/python/pypgstac/pypgstac.py
+++ b/src/pypgstac/python/pypgstac/pypgstac.py
@@ -67,13 +67,16 @@ class PgstacCLI:
         method: Optional[Methods] = Methods.insert,
         dehydrated: Optional[bool] = False,
         chunksize: Optional[int] = 10000,
+        partition_update_enabled: Optional[bool] = True,
     ) -> None:
         """Load collections or items into PGStac."""
         loader = Loader(db=self._db)
         if table == "collections":
             loader.load_collections(file, method)
         if table == "items":
-            loader.load_items(file, method, dehydrated, chunksize)
+            loader.load_items(
+                file, method, dehydrated, chunksize, partition_update_enabled,
+            )
 
     def runqueue(self) -> str:
         return self._db.run_queued()

--- a/src/pypgstac/tests/test_load.py
+++ b/src/pypgstac/tests/test_load.py
@@ -449,3 +449,20 @@ def test_load_items_nopartitionconstraint_succeeds(loader: Loader) -> None:
         """,
     )
     assert cdtmin == "2011-07-31 00:00:00+00"
+
+
+def test_load_items_when_partition_creation_disabled(loader: Loader) -> None:
+    """
+    Test pypgstac items loader raises an exception when partition
+    does not exist and partition creation is disabled.
+    """
+    loader.load_collections(
+        str(TEST_COLLECTIONS_JSON),
+        insert_mode=Methods.insert,
+    )
+    with pytest.raises(ValueError):
+        loader.load_items(
+            str(TEST_ITEMS),
+            insert_mode=Methods.insert,
+            partition_update_enabled=False,
+        )


### PR DESCRIPTION
We ingest images on a daily basis into the catalog and notice that using the `check_partition` function [here](https://github.com/stac-utils/pgstac/blob/1ea6c5df7cc79364e34ea9bee7693f9db2d922cd/src/pypgstac/python/pypgstac/load.py#L284C32-L284C47) significantly slows down the ingestion process. Since we have prior knowledge of the temporal data distribution, we can pre-create the necessary partitions with
```sql
SELECT check_partition(
    'collectionxxx',
    tstzrange('2023-10-01', '2023-11-01', '[)'),
    tstzrange('2023-10-01', '2023-11-01', '[)')
);
...
```
instead of checking them during every ingestion. This pull request offers an option to disable partition checking, enhancing the ingestion performance. If a required partition isn't created, the loader will raise an exception with an appropriate message.