### PR TITLE
Release for v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [v0.8.2]
 
 ## Added
 - Add support functions and tests for Collection Search
@@ -414,6 +414,7 @@ _TODO_
 
 - Fixed issue with pypgstac loads which caused some writes to fail ([#18](https://github.com/stac-utils/pgstac/pull/18))
 
+[v0.8.2]: https://github.com/stac-utils/pgstac/compare/v0.8.1...v0.8.2
 [v0.8.1]: https://github.com/stac-utils/pgstac/compare/v0.8.0...v0.8.1
 [v0.8.0]: https://github.com/stac-utils/pgstac/compare/v0.7.10...v0.8.0
 [v0.7.10]: https://github.com/stac-utils/pgstac/compare/v0.7.9...v0.7.10

--- a/src/pgstac/migrations/pgstac.0.8.1-0.8.2.sql
+++ b/src/pgstac/migrations/pgstac.0.8.1-0.8.2.sql
@@ -1394,4 +1394,4 @@ RESET ROLE;
 
 SET ROLE pgstac_ingest;
 SELECT update_partition_stats_q(partition) FROM partitions_view;
-SELECT set_version('unreleased');
+SELECT set_version('0.8.2');

--- a/src/pgstac/migrations/pgstac.0.8.2.sql
+++ b/src/pgstac/migrations/pgstac.0.8.2.sql
@@ -4380,4 +4380,4 @@ RESET ROLE;
 
 SET ROLE pgstac_ingest;
 SELECT update_partition_stats_q(partition) FROM partitions_view;
-SELECT set_version('unreleased');
+SELECT set_version('0.8.2');

--- a/src/pgstac/pgstac.sql
+++ b/src/pgstac/pgstac.sql
@@ -1,1 +1,1 @@
-migrations/pgstac.unreleased.sql
+migrations/pgstac.0.8.2.sql

--- a/src/pgstac/sql/999_version.sql
+++ b/src/pgstac/sql/999_version.sql
@@ -1,1 +1,1 @@
-SELECT set_version('unreleased');
+SELECT set_version('0.8.2');

--- a/src/pypgstac/pyproject.toml
+++ b/src/pypgstac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypgstac"
-version = "0.8.1-dev"
+version = "0.8.2"
 description = "Schema, functions and a python library for storing and accessing STAC collections and items in PostgreSQL"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pypgstac/python/pypgstac/version.py
+++ b/src/pypgstac/python/pypgstac/version.py
@@ -1,2 +1,2 @@
 """Version."""
-__version__ = "0.8.1-dev"
+__version__ = "0.8.2"


### PR DESCRIPTION
## Added
- Add support functions and tests for Collection Search
- Add configuration parameter for base_url to be able to generate absolute links
 - With this release, this is only used to create links for paging in collection_search
- Adds read only mode to allow use of pgstac on read replicas
 - Note: Turning on romode disables any caching (particularly when context is turned on) and does not allow to store q query hash that can be used with geometry_search.
- Add option to pypgstac loader "--usequeue" that forces use of the query queue for the loading process
- Add "pypgstac runqueue" command to run any commands that are set in the query queue

 ### Fixed
 - Fix bug with end_datetime constraint management leading to inability to add data outside of constraints
 - Fix bugs dealing with table ownership to ensure that all pgstac tables are owned by the pgstac_admin role
  - Fixes issues with errors/warnings caused when doing index maintenance
  - Fixes issues with errors/warnings caused with partition management
- Make sure that pgstac_ingest role always has read/write permissions on all tables
- Remove call to create_table_constraints from check_partition function. create_table_constraints was being called twice as it also gets called from update_partition_stats
- Add NOT NULL constraint to collections table (FIXES #224)
- Fix issue with indexes not getting created as the pg_admin role using SECURITY DEFINER

 ### Changed
 - Revert pydantic requirement back to '>=1.7' and use basesettings conditionally from pydantic or pydantic.v1 to allow compatibility with pydantic 2 as well as with stac-fastapi that requires pydantic <2