### PR TITLE
Fix for CI docker builds.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,7 @@ jobs:
 
   # This builds a base postgres image that has everything installed to be able to run pgstac. This image does not have pgstac itself installed.
   buildpg:
-    name: Build and push base postgres image (you will need to run pypgstac migrate to install pgstac)
+    name: Build and push base postgres image
     if: ${{ needs.changes.outputs.buildpgdocker == 'true' }}
     runs-on: ubuntu-latest
     needs: [changes]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,8 +45,9 @@ jobs:
         echo "pytag=${{ env.REGISTRY }}/stac-utils/pgstac-pyrust:$ref" >>$GITHUB_OUTPUT;
         echo "buildpy=$buildpg" >>$GITHUB_OUTPUT;
 
+  # This builds a base postgres image that has everything installed to be able to run pgstac. This image does not have pgstac itself installed.
   buildpg:
-    name: Build and push base postgres
+    name: Build and push base postgres image (you will need to run pypgstac migrate to install pgstac)
     if: ${{ needs.changes.outputs.buildpgdocker == 'true' }}
     runs-on: ubuntu-latest
     needs: [changes]
@@ -62,8 +63,9 @@ jobs:
       - name: Build and Push Base Postgres
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
-          target: pgstacbase-plrust
+          target: pgstacbase
           file: docker/pgstac/Dockerfile
           tags: ${{ needs.changes.outputs.pgdocker }}
           push: true
@@ -87,6 +89,7 @@ jobs:
       - name: Build and Push Base pyrust
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           target: pyrustbase
           file: docker/pypgstac/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
   # This builds a base postgres image that has everything installed to be able to run pgstac.
   buildpg:
-    name: Build and push base postgres image (you will need to run pypgstac migrate to install pgstac)
+    name: Build and push base postgres image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
 
-
+  # This builds a base postgres image that has everything installed to be able to run pgstac.
   buildpg:
-    name: Build and push base postgres
+    name: Build and push base postgres image (you will need to run pypgstac migrate to install pgstac)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          target: pgstacbase-plrust
+          target: pgstacbase
           file: docker/pgstac/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -54,8 +54,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha, mode=max
 
+  # This builds a postgres image that already has pgstac installed to the tagged version
   buildpgstac:
-    name: Build and push base postgres
+    name: Build and push base postgres with pgstac installed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -78,7 +79,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          target: pgstac-plrust
+          target: pgstac
           file: docker/pgstac/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/pgstac/Dockerfile
+++ b/docker/pgstac/Dockerfile
@@ -1,6 +1,7 @@
 ARG PG_MAJOR=15
 ARG POSTGIS_MAJOR=3
 
+# Base postgres image that pgstac can be installed onto
 FROM postgres:${PG_MAJOR}-bullseye as pgstacbase
 ARG POSTGIS_MAJOR
 RUN  \
@@ -17,6 +18,7 @@ RUN  \
     && rm -rf /var/lib/apt/lists/*
 COPY docker/pgstac/dbinit/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
+# Base postgres image with plrust installed that can be used for future development using plrust
 FROM pgstacbase as pgstacbase-plrust
 ENV PLRUSTVERSION=1.2.3
 ENV RUSTVERSION=1.72.0
@@ -60,11 +62,13 @@ COPY docker/pgstac/dbinit/pgstac-rust.sh 991_plrust.sh
 USER root
 RUN apt-get install -y /${PLRUSTFILE}
 
+# The pgstacbase image with latest version of pgstac installed
 FROM pgstacbase as pgstac
 WORKDIR /docker-entrypoint-initdb.d
 COPY docker/pgstac/dbinit/pgstac.sh 990_pgstac.sh
 COPY src/pgstac/pgstac.sql 999_pgstac.sql
 
+# The pgstacbase-plrust image with the latest version of pgstac installed
 FROM pgstacbase-plrust as pgstac-plrust
 WORKDIR /docker-entrypoint-initdb.d
 COPY docker/pgstac/dbinit/pgstac.sh 990_pgstac.sh

--- a/docker/pgstac/Dockerfile
+++ b/docker/pgstac/Dockerfile
@@ -20,7 +20,7 @@ COPY docker/pgstac/dbinit/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.
 
 # Base postgres image with plrust installed that can be used for future development using plrust
 FROM pgstacbase as pgstacbase-plrust
-ENV PLRUSTVERSION=1.2.3
+ENV PLRUSTVERSION=1.2.7
 ENV RUSTVERSION=1.72.0
 ENV PLRUSTDOWNLOADURL=https://github.com/tcdi/plrust/releases/download/
 ENV PLRUSTFILE=plrust-trusted-${PLRUSTVERSION}_${RUSTVERSION}-debian-pg${PG_MAJOR}-amd64.deb

--- a/docker/pgstac/Dockerfile
+++ b/docker/pgstac/Dockerfile
@@ -19,7 +19,7 @@ COPY docker/pgstac/dbinit/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.
 
 FROM pgstacbase as pgstacbase-plrust
 ENV PLRUSTVERSION=1.2.3
-ENV RUSTVERSION=1.70.0
+ENV RUSTVERSION=1.72.0
 ENV PLRUSTDOWNLOADURL=https://github.com/tcdi/plrust/releases/download/
 ENV PLRUSTFILE=plrust-trusted-${PLRUSTVERSION}_${RUSTVERSION}-debian-pg${PG_MAJOR}-amd64.deb
 ENV PLRUSTURL=${PLRUSTDOWNLOADURL}v${PLRUSTVERSION}/${PLRUSTFILE}

--- a/docker/pypgstac/bin/test
+++ b/docker/pypgstac/bin/test
@@ -151,14 +151,14 @@ ALTER DATABASE pgstac_test_migration SET search_path to pgstac, public;
 ALTER DATABASE pgstac_test_migration SET client_min_messages to $CLIENTMESSAGES;
 EOSQL
     export PGDATABASE=pgstac_test_migration
-    echo "Migrating from version 0.1.9"
+    echo "Migrating from version 0.3.0"
     cd $SRCDIR/pypgstac
     python -m venv venv
     source venv/bin/activate
     pip install --cache /tmp/.pipcache --upgrade pip
     pip install --cache /tmp/.pipcache -e .[dev,test,psycopg]
 
-    pypgstac migrate --toversion 0.1.9
+    pypgstac migrate --toversion 0.3.0
     pypgstac --version
 
     pypgstac migrate


### PR DESCRIPTION
The docker image for pgstac has four targets.

- pgstacbase: This target is essentially the same as postgis/postgis with pgtap, plpgsql-check, and partman installed (which are used for testing/development, but not required for using pgstac), it is a base postgres/postgis image that is ready to install pgstac, but does not have it installed yet.
- pgstacbase-plrust: This is the pgstacbase image that also has PLRUST installed in preparation for future development (PLRUST is not used yet).
- pgstac: This target is the pgstacbase image with pgstac already installed at a specific version
- pgstac-rust: This target is the pgstacbase-plrust image with pgstac already installed at a specific version

CI ran into issues with building the pgstacbase-plrust and pgstac-plrust targets. This PR does three things:

- Update the pgstacbase-plrust target with the latest PLRUST version
- Modify the CI release to push the pgstacbase and pgstac targets rather than the PLRUST targets as PLRUST is not used yet.
- Update the incremental migration tests to start at v0.3.0 rather than v0.1.9 due to a breaking change in pg_partman at version 5 that has no ability to pin a version.
