### PR TITLE
Enable querying of the geometry column

### DIFF
--- a/src/pgstac/sql/002b_cql.sql
+++ b/src/pgstac/sql/002b_cql.sql
@@ -273,7 +273,7 @@ BEGIN
         FOR prop IN
             SELECT DISTINCT p->>0
             FROM jsonb_path_query(j, 'strict $.**.property') p
-            WHERE p->>0 NOT IN ('id', 'datetime', 'end_datetime', 'collection')
+            WHERE p->>0 NOT IN ('id', 'datetime', 'geometry', 'end_datetime', 'collection')
         LOOP
             IF (queryable(prop)).nulled_wrapper IS NULL THEN
                 RAISE EXCEPTION 'Term % is not found in queryables.', prop;

--- a/src/pgstac/tests/pgtap/002a_queryables.sql
+++ b/src/pgstac/tests/pgtap/002a_queryables.sql
@@ -98,6 +98,11 @@ SELECT lives_ok(
 );
 
 SELECT lives_ok(
+    $$ SELECT search('{"filter": {"s_intersects": [{"property": "geometry"}, {"type": "Point", "coordinates": [0, 0]}]}}'); $$,
+    'Make sure a term present in the list of queryables can be used in a filter'
+)
+
+SELECT lives_ok(
     $$ SELECT search('{"filter": {"and": [{"t_after": [{"property": "datetime"}, "2020-11-11T00:00:00"]}, {"t_before": [{"property": "datetime"}, "2022-11-11T00:00:00"]}]}}'); $$,
     'Make sure that only arguments that are properties are checked'
 );


### PR DESCRIPTION
In strict mode, PgSTAC returns an error even though the `geometry` column is listed in the `queryables` table:

```
Term geometry is not found in queryables.
```