### PR TITLE
Fix documentation typo (cql-json2 -> cql2-json)

### DIFF
--- a/docs/src/pgstac.md
+++ b/docs/src/pgstac.md
@@ -46,7 +46,7 @@ kwargs={
 ```
 
 #### PgSTAC Settings Variables
-There are additional variables that control the settings used for calculating and displaying context (total row count) for a search, as well as a variable to set the filter language (cql-json or cql-json2).
+There are additional variables that control the settings used for calculating and displaying context (total row count) for a search, as well as a variable to set the filter language (cql-json or cql2-json).
 The context is "off" by default, and the default filter language is set to "cql2-json".
 
 Variables can be set either by passing them in via the connection options using your connection library, setting them in the pgstac_settings table or by setting them on the Role that is used to log in to the database.


### PR DESCRIPTION
Hi all! 

This PR is correcting what I _think_ is a tiny typo in the docs: the filter languages are either CQL JSON or CQL2 JSON, not CQL JSON2. This also matches the allowed levels of the variable.