### PR TITLE
Update rust re-hydration code to pyo3 0.21

### DIFF
--- a/src/pypgstac/Cargo.lock
+++ b/src/pypgstac/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/src/pypgstac/Cargo.lock
+++ b/src/pypgstac/Cargo.lock
@@ -27,10 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "indoc"
-version = "1.0.9"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "libc"
@@ -95,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
+checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -115,6 +127,7 @@ dependencies = [
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -123,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
+checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -133,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
+checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -143,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
+checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -155,11 +168,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
+checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
 dependencies = [
+ "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -196,9 +211,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -219,9 +234,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-targets"

--- a/src/pypgstac/Cargo.toml
+++ b/src/pypgstac/Cargo.toml
@@ -11,4 +11,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-pyo3 = { version = "0.19.1", features = ["abi3-py38", "extension-module", "anyhow"] }
+pyo3 = { version = "0.20", features = [
+    "abi3-py38",
+    "extension-module",
+    "anyhow",
+] }

--- a/src/pypgstac/Cargo.toml
+++ b/src/pypgstac/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-pyo3 = { version = "0.20", features = [
+pyo3 = { version = "0.21", features = [
     "abi3-py38",
     "extension-module",
     "anyhow",

--- a/src/pypgstac/src/lib.rs
+++ b/src/pypgstac/src/lib.rs
@@ -65,7 +65,7 @@ fn hydrate_list<'a>(base: &PyList, item: &'a PyList) -> PyResult<&'a PyList> {
 
 fn hydrate_dict<'a>(base: &PyDict, item: &'a PyDict) -> PyResult<&'a PyDict> {
     for (key, base_value) in base {
-        if let Some(item_value) = item.get_item(key) {
+        if let Some(item_value) = item.get_item(key)? {
             if item_value
                 .downcast::<PyString>()
                 .ok()
@@ -73,7 +73,7 @@ fn hydrate_dict<'a>(base: &PyDict, item: &'a PyDict) -> PyResult<&'a PyDict> {
                 .map(|s| s == MAGIC_MARKER)
                 .unwrap_or(false)
             {
-                item.del_item(&key)?;
+                item.del_item(key)?;
             } else {
                 item.set_item(key, hydrate(base_value, item_value)?)?;
             }

--- a/src/pypgstac/src/lib.rs
+++ b/src/pypgstac/src/lib.rs
@@ -22,28 +22,40 @@
 )]
 
 use anyhow::anyhow;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::{
     prelude::*,
-    types::{PyDict, PyList, PyString},
+    types::{PyDict, PyList},
 };
 
 const MAGIC_MARKER: &str = "𒍟※";
 
 #[pyfunction]
-fn hydrate<'a>(base: &PyAny, item: &'a PyAny) -> PyResult<&'a PyAny> {
+fn hydrate<'py>(
+    base: &'py Bound<'py, PyAny>,
+    item: &'py Bound<'py, PyAny>,
+) -> PyResult<&'py Bound<'py, PyAny>> {
     hydrate_any(base, item)
 }
 
-fn hydrate_any<'a>(base: &PyAny, item: &'a PyAny) -> PyResult<&'a PyAny> {
+fn hydrate_any<'py>(
+    base: &'py Bound<'py, PyAny>,
+    item: &'py Bound<'py, PyAny>,
+) -> PyResult<&'py Bound<'py, PyAny>> {
     if let Ok(item) = item.downcast::<PyDict>() {
         if let Ok(base) = base.downcast::<PyDict>() {
-            hydrate_dict(base, item).map(|item| item.into())
+            let result = hydrate_dict(base, item);
+            Ok(result?.as_any())
+            // todo!()
+            //  .map(|item| item.into())
         } else {
             Err(anyhow!("type mismatch").into())
         }
     } else if let Ok(item) = item.downcast::<PyList>() {
         if let Ok(base) = base.downcast::<PyList>() {
-            hydrate_list(base, item).map(|item| item.into())
+            let result = hydrate_list(base, item)?;
+            Ok(result.as_any())
+            // .map(|item| item.into())
         } else {
             Err(anyhow!("type mismatch").into())
         }
@@ -52,30 +64,35 @@ fn hydrate_any<'a>(base: &PyAny, item: &'a PyAny) -> PyResult<&'a PyAny> {
     }
 }
 
-fn hydrate_list<'a>(base: &PyList, item: &'a PyList) -> PyResult<&'a PyList> {
+fn hydrate_list<'py>(
+    base: &'py Bound<'py, PyList>,
+    item: &'py Bound<'py, PyList>,
+) -> PyResult<&'py Bound<'py, PyList>> {
     for i in 0..item.len() {
         if i >= base.len() {
             return Ok(item);
         } else {
-            item.set_item(i, hydrate(&base[i], &item[i])?)?;
+            item.set_item(i, hydrate(&base.get_item(i)?, &item.get_item(i)?)?)?;
         }
     }
     Ok(item)
 }
 
-fn hydrate_dict<'a>(base: &PyDict, item: &'a PyDict) -> PyResult<&'a PyDict> {
+fn hydrate_dict<'py>(
+    base: &'py Bound<'py, PyDict>,
+    item: &'py Bound<'py, PyDict>,
+) -> PyResult<&'py Bound<'py, PyDict>> {
     for (key, base_value) in base {
-        if let Some(item_value) = item.get_item(key)? {
+        if let Some(item_value) = item.get_item(&key)? {
             if item_value
-                .downcast::<PyString>()
+                .extract::<PyBackedStr>()
                 .ok()
-                .and_then(|value| value.to_str().ok())
-                .map(|s| s == MAGIC_MARKER)
+                .map(|s| <PyBackedStr as AsRef<str>>::as_ref(&s) == MAGIC_MARKER)
                 .unwrap_or(false)
             {
                 item.del_item(key)?;
             } else {
-                item.set_item(key, hydrate(base_value, item_value)?)?;
+                item.set_item(&key, hydrate(&base_value, &item_value)?)?;
             }
         } else {
             item.set_item(key, base_value)?;
@@ -85,7 +102,7 @@ fn hydrate_dict<'a>(base: &PyDict, item: &'a PyDict) -> PyResult<&'a PyDict> {
 }
 
 #[pymodule]
-fn pgstacrs(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn pgstacrs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(crate::hydrate, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
There were a bunch of pyo3 changes from 0.20 to 0.21, namely the [introduction of the `Bound` smart pointer.](https://pyo3.rs/v0.21.2/migration#from-020-to-021) I've not fully grokked my head around it, but this compiles without any of the deprecated "gil-refs" code.

As well as keeping up to date with the latest dependency versions, this has the potential to decently improve performance for code that interacts heavily with the Python interpreter, such as the rehydration code.