### PR TITLE
stage version 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-### Unreleased
+### [v0.9.1]
 
 ### Fixed
 - Fixed double nested extent when using trigger based update collection extent. (Fixes #274)
+- Fix time formatting (Fixes #275)
+- Relaxes smart-open dependency check (Fixes #273)
+- Switch to uv for docker image
+
 
 ### [v0.9.0]
 

--- a/src/pgstac/migrations/pgstac.0.9.0-0.9.1.sql
+++ b/src/pgstac/migrations/pgstac.0.9.0-0.9.1.sql
@@ -393,4 +393,4 @@ RESET ROLE;
 
 SET ROLE pgstac_ingest;
 SELECT update_partition_stats_q(partition) FROM partitions_view;
-SELECT set_version('unreleased');
+SELECT set_version('0.9.1');

--- a/src/pgstac/migrations/pgstac.0.9.1.sql
+++ b/src/pgstac/migrations/pgstac.0.9.1.sql
@@ -4492,4 +4492,4 @@ RESET ROLE;
 
 SET ROLE pgstac_ingest;
 SELECT update_partition_stats_q(partition) FROM partitions_view;
-SELECT set_version('unreleased');
+SELECT set_version('0.9.1');

--- a/src/pgstac/pgstac.sql
+++ b/src/pgstac/pgstac.sql
@@ -1,1 +1,1 @@
-migrations/pgstac.unreleased.sql
+migrations/pgstac.0.9.1.sql

--- a/src/pgstac/sql/999_version.sql
+++ b/src/pgstac/sql/999_version.sql
@@ -1,1 +1,1 @@
-SELECT set_version('unreleased');
+SELECT set_version('0.9.1');

--- a/src/pypgstac/pyproject.toml
+++ b/src/pypgstac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypgstac"
-version = "0.9.0-dev"
+version = "0.9.1"
 description = "Schema, functions and a python library for storing and accessing STAC collections and items in PostgreSQL"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pypgstac/python/pypgstac/version.py
+++ b/src/pypgstac/python/pypgstac/version.py
@@ -1,2 +1,2 @@
 """Version."""
-__version__ = "0.9.0-dev"
+__version__ = "0.9.1"


### PR DESCRIPTION
Stage recent changes for release.

- Fixed double nested extent when using trigger based update collection extent. (Fixes #274)
- Fix time formatting (Fixes #275)
- Relaxes smart-open dependency check (Fixes #273)
- Switch to uv for docker image