### PR TITLE
Don't mount local folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       - PGUSER=username
       - PGPASSWORD=password
       - PGDATABASE=postgis
-    volumes:
-      - .:/opt
     depends_on:
       - pgstac
 volumes:


### PR DESCRIPTION
Fixes #260.

Otherwise, the Rust extension module will not be accessible.