### PR TITLE
Update maintain_partition_queries format

### DIFF
--- a/src/pgstac/sql/002a_queryables.sql
+++ b/src/pgstac/sql/002a_queryables.sql
@@ -358,9 +358,7 @@ BEGIN
         SELECT * FROM queryable_indexes(part,true)
     ) LOOP
         q := format(
-            'SELECT maintain_index(
-                %L,%L,%L,%L,%L
-            );',
+            'SELECT maintain_index(%L, %L, %L, %L, %L);',
             rec.indexname,
             rec.queryable_idx,
             dropindexes,


### PR DESCRIPTION
Fixes `query_queue` table being poorly formatted:

```
postgis=> select * from pgstac.query_queue;
                                  query                                  |             added             
-------------------------------------------------------------------------+-------------------------------
 SELECT update_partition_stats('_items_19362_202407', 'f');              | 2024-07-02 13:26:12.703653+00
 SELECT update_partition_stats('_items_19363_202407', 'f');              | 2024-07-02 13:26:12.8475+00
 SELECT maintain_index(                                                 +| 2024-07-02 13:34:41.589782+00
                                                                        +| 
                 '_items_19362_202407_end_datetime_idx',NULL,'f','f','f'+| 
                                                                        +| 
             );                                                          | 
 SELECT update_partition_stats('_items_19362_202407', 't');              | 2024-07-02 13:34:41.589782+00
 SELECT maintain_index(                                                 +| 2024-07-02 13:34:41.821157+00
                                                                        +| 
                 '_items_19363_202407_end_datetime_idx',NULL,'f','f','f'+| 
                                                                        +| 
             );
```