### PR TITLE
Allow read-only replicas work even when the context extension is enabled

### DIFF
--- a/src/pgstac/sql/004_search.sql
+++ b/src/pgstac/sql/004_search.sql
@@ -541,9 +541,14 @@ BEGIN
         RETURN sw;
     END IF;
 
-    -- Get any stats that we have. If there is a lock where another process is
-    -- updating the stats, wait so that we don't end up calculating a bunch of times.
-    SELECT * INTO sw FROM search_wheres WHERE md5(_where)=inwhere_hash FOR UPDATE;
+    -- Get any stats that we have.
+    IF NOT ro THEN
+        -- If there is a lock where another process is
+        -- updating the stats, wait so that we don't end up calculating a bunch of times.
+        SELECT * INTO sw FROM search_wheres WHERE md5(_where)=inwhere_hash FOR UPDATE;
+    ELSE
+        SELECT * INTO sw FROM search_wheres WHERE md5(_where)=inwhere_hash;
+    END IF;
 
     -- If there is a cached row, figure out if we need to update
     IF


### PR DESCRIPTION
It fixes the following issue:
```
postgis=> SELECT search('{}');
NOTICE:  SEARCH: {}
NOTICE:  FILTER: <NULL>
ERROR:  cannot execute SELECT FOR UPDATE in a read-only transaction
CONTEXT:  SQL statement "SELECT *         FROM search_wheres WHERE md5(_where)=inwhere_hash FOR UPDATE"
PL/pgSQL function where_stats(text,boolean,jsonb) line 57 at SQL statement
PL/pgSQL function search(jsonb) line 65 at assignment
```

I proposed the test in another PR: https://github.com/stac-utils/pgstac/pull/297