### PR TITLE
Fix string interpolation

### DIFF
--- a/src/pgstac/sql/002a_queryables.sql
+++ b/src/pgstac/sql/002a_queryables.sql
@@ -367,7 +367,7 @@ BEGIN
             rebuildindexes,
             idxconcurrently
         );
-        RAISE NOTICE 'Q: %s', q;
+        RAISE NOTICE 'Q: %', q;
         RETURN NEXT q;
     END LOOP;
     RETURN;


### PR DESCRIPTION
From the [docs](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html):
> Inside the format string, % is replaced by the string representation of the next optional argument's value