### PR TITLE
switch from server_version to server_version_num

### DIFF
--- a/src/pypgstac/python/pypgstac/db.py
+++ b/src/pypgstac/python/pypgstac/db.py
@@ -271,15 +271,18 @@ class PgstacDB:
         """Get the current pg version number from a pgstac database."""
         version = self.query_one(
             """
-            SHOW server_version;
+            SHOW server_version_num;
             """,
         )
         logger.debug(f"PG VERSION: {version}.")
         if isinstance(version, bytes):
             version = version.decode()
         if isinstance(version, str):
-            if int(version.split(".")[0]) < 13:
-                raise Exception("PgSTAC requires PostgreSQL 13+")
+            if int(version) < 130000:
+                major, minor, patch = tuple(
+                    map(int, [version[i:i + 2] for i in range(0, len(version), 2)]),
+                )
+                raise Exception(f"PgSTAC requires PostgreSQL 13+, current version is: {major}.{minor}.{patch}")  # noqa: E501
             return version
         else:
             if self.connection is not None:

--- a/src/pypgstac/python/pypgstac/migrate.py
+++ b/src/pypgstac/python/pypgstac/migrate.py
@@ -122,8 +122,16 @@ class Migrate:
             logger.info("using unreleased version")
             toversion = "unreleased"
 
-        pg_version = self.db.pg_version
-        logger.info(f"Migrating PgSTAC on PostgreSQL Version {pg_version}")
+        major, minor, patch = tuple(
+            map(
+                int,
+                [
+                    self.db.pg_version[i:i + 2]
+                    for i in range(0, len(self.db.pg_version), 2)
+                ],
+            ),
+        )
+        logger.info(f"Migrating PgSTAC on PostgreSQL Version {major}.{minor}.{patch}")
         oldversion = self.db.version
         if oldversion == toversion:
             logger.info(f"Target database already at version: {toversion}")


### PR DESCRIPTION
ref: https://github.com/stac-utils/stac-fastapi-pgstac/issues/147

When using beta version of Postgres (e.g `17beta3`) the current code using `server_version` would fail. Using `server_version_num` overcome this and avoid having to parse the version number 