### PR TITLE
Allow docker entrypoint to execute `psql` command in shell script if `PGHOST` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `open=True` in `psycopg.ConnectionPool` to avoid future behavior change
 - Switch from postgres `server_version` to `server_version_num` to get PG version (Fixes #300)
 - Allow read-only replicas work even when the context extension is enabled (Fixes #300)
+- Allow docker entrypoint to execute `psql` command in shell script if `PGHOST` is set (Fixes #318)
 
 ## [v0.9.1]
 


### PR DESCRIPTION
This resolves #318 by temporarily making the `psql` command an alias for `docker_process_sql` and exporting it so that it can be used in executed shell scripts. 

This change is only applied for the duration of the `docker_process_init_files` function so it should not affect any other calls to `psql` in the container.

To test this: 

```sh
docker run --rm -e 'POSTGRES_USER=username' -e 'PGUSER=username' -e 'POSTGRES_PASSWORD=password' -e 'POSTGRES_DB=postgis' -e 'PGDATABASE=postgis' -e 'PGHOST=localhost' ghcr.io/stac-utils/pgstac:v0.9.1 postgres
```

The above command should run with no failures
