### PR TITLE
psql17 partition_steps.name fix

### DIFF
--- a/src/pgstac/sql/003b_partitions.sql
+++ b/src/pgstac/sql/003b_partitions.sql
@@ -95,7 +95,7 @@ CREATE UNIQUE INDEX ON partitions (partition);
 
 CREATE MATERIALIZED VIEW partition_steps AS
 SELECT
-    partition as name,
+    split_part(partition, '.', -1) AS name,
     date_trunc('month',lower(partition_dtrange)) as sdate,
     date_trunc('month', upper(partition_dtrange)) + '1 month'::interval as edate
     FROM partitions_view WHERE partition_dtrange IS NOT NULL AND partition_dtrange != 'empty'::tstzrange


### PR DESCRIPTION
In psql17 partition_steps.name got schema attached and it brakes chunker. The change ensures that schema is not in the name.
resolves #309 