### PR TITLE
Run continuous integration tests when code is changed in the `src` directory as well

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,8 +31,10 @@ jobs:
           filters: |
             pgstac:
               - 'docker/pgstac/**'
+              - 'src/pgstac/pgstac.sql'
             pypgstac:
               - 'docker/pypgstac/**'
+              - 'src/**'
       - id: check
         run: |
           buildpg=false;
@@ -101,6 +103,7 @@ jobs:
   test:
     name: test
     needs: [changes, buildpg, buildpyrust]
+    if: ${{ needs.changes.outputs.buildpgdocker == 'true' || needs.changes.outputs.buildpyrustdocker == 'true' }}
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.changes.outputs.pyrustdocker }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `open=True` in `psycopg.ConnectionPool` to avoid future behavior change
 - Switch from postgres `server_version` to `server_version_num` to get PG version (Fixes #300)
 - Allow read-only replicas work even when the context extension is enabled (Fixes #300)
+- Run continuous integration tests when code is changed in the `src` directory as well (Fixes #321)
 
 ## [v0.9.1]
 

--- a/docker/pypgstac/bin/test
+++ b/docker/pypgstac/bin/test
@@ -46,10 +46,10 @@ function test_formatting(){
     cd $SRCDIR/pypgstac
 
     echo "Running ruff"
-    ruff -n python tests
+    ruff -n src tests
 
     echo "Running mypy"
-    mypy python
+    mypy src
 
     echo "Checking if there are any staged migrations."
     find $SRCDIR/pgstac/migrations | grep 'staged' && { echo "There are staged migrations in pypgstac/migrations. Please check migrations and remove staged suffix."; exit 1; }

--- a/src/pypgstac/src/pypgstac/load.py
+++ b/src/pypgstac/src/pypgstac/load.py
@@ -492,12 +492,12 @@ class Loader:
                 ),
             )
             if db_rows:
-                datetime_range_min: Optional[datetime] = db_rows[0][0] or datetime.min
-                datetime_range_max: Optional[datetime] = db_rows[0][1] or datetime.max
-                end_datetime_range_min: Optional[datetime] = (
+                datetime_range_min: datetime = db_rows[0][0] or datetime.min
+                datetime_range_max: datetime = db_rows[0][1] or datetime.max
+                end_datetime_range_min: datetime = (
                     db_rows[0][2] or datetime.min
                 )
-                end_datetime_range_max: Optional[datetime] = (
+                end_datetime_range_max: datetime = (
                     db_rows[0][3] or datetime.max
                 )
 


### PR DESCRIPTION
This fixes #321 by building new docker images when **any** of the relevant files have changed (not just the ones in the `docker/` directory.

Tests will run if either of the images are built which indicates that the code has changed in a way that requires testings. If neither images are built, this means that the testable code has not changed and the tests will not run.

This PR also fixes some errors reported by mypy and ruff while running the tests.