### PR TITLE
always run tests even if docker images don't rebuild

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,15 +40,14 @@ jobs:
           [[ "${{ steps.filter.outputs.pgstac }}" == "true" ]] && buildpg=true || ref=main;
           echo "pgtag=${{ env.REGISTRY }}/stac-utils/pgstac-postgres:$ref" >>$GITHUB_OUTPUT;
           echo "buildpg=$buildpg" >>$GITHUB_OUTPUT;
-          buildy=false;
+          buildpy=false;
           [[ "${{ steps.filter.outputs.pypgstac }}" == "true" ]] && buildpy=true || ref=main;
           echo "pytag=${{ env.REGISTRY }}/stac-utils/pgstac-pyrust:$ref" >>$GITHUB_OUTPUT;
-          echo "buildpy=$buildpg" >>$GITHUB_OUTPUT;
+          echo "buildpy=$buildpy" >>$GITHUB_OUTPUT;
 
   # This builds a base postgres image that has everything installed to be able to run pgstac. This image does not have pgstac itself installed.
   buildpg:
     name: Build and push base postgres image
-    if: ${{ needs.changes.outputs.buildpgdocker == 'true' }}
     runs-on: ubuntu-latest
     needs: [changes]
     steps:
@@ -61,6 +60,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Base Postgres
+        if: ${{ needs.changes.outputs.buildpgdocker == 'true' }}
         uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64
@@ -74,7 +74,6 @@ jobs:
 
   buildpyrust:
     name: Build and push base pyrust
-    if: ${{ needs.changes.outputs.buildpyrustdocker == 'true' }}
     runs-on: ubuntu-latest
     needs: [changes]
     steps:
@@ -87,6 +86,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Base pyrust
+        if: ${{ needs.changes.outputs.buildpyrustdocker == 'true' }}
         uses: docker/build-push-action@v4
         with:
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Rather than adding the `if: changes` logic at the job-level, add it at the actual build and push step.