### PR TITLE
Udpate fire to 0.7.0

### DIFF
--- a/src/pypgstac/pyproject.toml
+++ b/src/pypgstac/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "cachetools>=5.3.0",
-    "fire>=0.4.0",
+    "fire>=0.7.0",
     "hydraters>=0.1.0",
     "orjson>=3.7.0",
     "plpygis>=0.5.0",


### PR DESCRIPTION
Fixes https://github.com/stac-utils/pgstac/issues/328. The [fix](https://github.com/google/python-fire/pull/447) was included in the 0.7.0 release.