### PR TITLE
fix: reset connection on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED]
 
 * changed container images to use non-root `user`
+* fix bug where closed and broken db connections are reused.
 
 ## [v0.9.8]
 

--- a/src/pypgstac/src/pypgstac/db.py
+++ b/src/pypgstac/src/pypgstac/db.py
@@ -105,7 +105,7 @@ class PgstacDB:
     def connect(self) -> Connection:
         """Return database connection."""
         pool = self.get_pool()
-        if self.connection is None:
+        if self.connection is None or self.connection.closed or self.connection.broken:
             self.connection = pool.getconn()
             self.connection.autocommit = True
             if self.debug:


### PR DESCRIPTION
This PR fixes a bug in the connect() function of pypgstacDB where closed and broken connections continue to be used, leading to errors.