### PR TITLE
pypgstac: lift version constraint on cachetools

### DIFF
--- a/src/pypgstac/pyproject.toml
+++ b/src/pypgstac/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "cachetools>=5.3.0,<6.1",
+    "cachetools>=5.3.0",
     "fire>=0.7.0",
     "hydraters>=0.1.0",
     "orjson>=3.9.0",


### PR DESCRIPTION
The current version restriction forbids to use pypgstac alongside recent versions of cachetools ([7.0.5](https://pypi.org/project/cachetools/7.0.5/) right now)