### PR TITLE
fix: properties column for indexdef()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `flake8`, `black`, and `mypy` removed from dev dependencies.
 
 ### Fixed
+- Generate JSON property indexes against the split `properties` column instead of the removed `content` column.
 - Explicit search stats refresh now propagates through cached and uncached search paths when `updatestats` is requested, keeping `numberMatched`/context counts current.
 - `scripts/container-scripts/test` now refreshes collation metadata for the
   `postgres` database during setup to avoid noisy warning output.

--- a/src/pgstac/migrations/pgstac--0.9.11--unreleased.sql
+++ b/src/pgstac/migrations/pgstac--0.9.11--unreleased.sql
@@ -4299,7 +4299,7 @@ AS $function$
                 q.property_path
             );
         ELSE
-            out := format($q$CREATE INDEX ON %%I USING %s (%s(((content -> 'properties'::text) -> %L::text)))$q$,
+            out := format($q$CREATE INDEX ON %%I USING %s (%s((properties -> %L::text)))$q$,
                 lower(COALESCE(q.property_index_type, 'BTREE')),
                 lower(COALESCE(q.property_wrapper, 'to_text')),
                 q.name
@@ -5093,6 +5093,7 @@ WITH p AS (
             regexp_replace(btrim(replace(replace(indexdef, indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as iidx,
             COALESCE(
                 substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+                substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
             ) AS field
@@ -6205,7 +6206,7 @@ create or replace view "pgstac"."pgstac_indexes" as  SELECT schemaname,
     tablename,
     indexname,
     regexp_replace(btrim(replace(replace(indexdef, indexname::text, ''::text), 'pgstac.'::text, ''::text), ' \t\n'::text), '[ ]+'::text, ' '::text, 'g'::text) AS idx,
-    COALESCE("substring"(indexdef, '\(([a-zA-Z0-9_]+)\)'::text), "substring"(indexdef, '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'::text),
+    COALESCE("substring"(indexdef, '\(([a-zA-Z0-9_]+)\)'::text), "substring"(indexdef, 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'::text), "substring"(indexdef, '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'::text),
         CASE
             WHEN indexdef ~* '\(datetime desc, end_datetime\)'::text THEN 'datetime'::text
             ELSE NULL::text
@@ -6220,7 +6221,7 @@ create or replace view "pgstac"."pgstac_indexes_stats" as  SELECT i.schemaname,
     i.tablename,
     i.indexname,
     i.indexdef,
-    COALESCE("substring"(i.indexdef, '\(([a-zA-Z0-9_]+)\)'::text), "substring"(i.indexdef, '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_]+)''::text'::text),
+    COALESCE("substring"(i.indexdef, '\(([a-zA-Z0-9_]+)\)'::text), "substring"(i.indexdef, 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'::text), "substring"(i.indexdef, '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_]+)''::text'::text),
         CASE
             WHEN i.indexdef ~* '\(datetime desc, end_datetime\)'::text THEN 'datetime_end_datetime'::text
             ELSE NULL::text
@@ -6911,7 +6912,7 @@ AS $function$
                 q.property_path
             );
         ELSE
-            out := format($q$CREATE INDEX ON %%I USING %s (%s(((content -> 'properties'::text) -> %L::text)))$q$,
+            out := format($q$CREATE INDEX ON %%I USING %s (%s((properties -> %L::text)))$q$,
                 lower(COALESCE(q.property_index_type, 'BTREE')),
                 lower(COALESCE(q.property_wrapper, 'to_text')),
                 q.name
@@ -7290,6 +7291,7 @@ WITH p AS (
             regexp_replace(btrim(replace(replace(indexdef, indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as iidx,
             COALESCE(
                 substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+                substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
             ) AS field

--- a/src/pgstac/migrations/pgstac--unreleased.sql
+++ b/src/pgstac/migrations/pgstac--unreleased.sql
@@ -1548,7 +1548,7 @@ CREATE OR REPLACE FUNCTION indexdef(q queryables) RETURNS text AS $$
                 q.property_path
             );
         ELSE
-            out := format($q$CREATE INDEX ON %%I USING %s (%s(((content -> 'properties'::text) -> %L::text)))$q$,
+            out := format($q$CREATE INDEX ON %%I USING %s (%s((properties -> %L::text)))$q$,
                 lower(COALESCE(q.property_index_type, 'BTREE')),
                 lower(COALESCE(q.property_wrapper, 'to_text')),
                 q.name
@@ -1567,6 +1567,7 @@ SELECT
     regexp_replace(btrim(replace(replace(indexdef, i.indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as idx,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
     ) AS field,
@@ -1585,6 +1586,7 @@ SELECT
     indexdef,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime_end_datetime' ELSE NULL END
     ) AS field,
@@ -1631,6 +1633,7 @@ WITH p AS (
             regexp_replace(btrim(replace(replace(indexdef, indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as iidx,
             COALESCE(
                 substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+                substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
             ) AS field

--- a/src/pgstac/pgstac.sql
+++ b/src/pgstac/pgstac.sql
@@ -1548,7 +1548,7 @@ CREATE OR REPLACE FUNCTION indexdef(q queryables) RETURNS text AS $$
                 q.property_path
             );
         ELSE
-            out := format($q$CREATE INDEX ON %%I USING %s (%s(((content -> 'properties'::text) -> %L::text)))$q$,
+            out := format($q$CREATE INDEX ON %%I USING %s (%s((properties -> %L::text)))$q$,
                 lower(COALESCE(q.property_index_type, 'BTREE')),
                 lower(COALESCE(q.property_wrapper, 'to_text')),
                 q.name
@@ -1567,6 +1567,7 @@ SELECT
     regexp_replace(btrim(replace(replace(indexdef, i.indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as idx,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
     ) AS field,
@@ -1585,6 +1586,7 @@ SELECT
     indexdef,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime_end_datetime' ELSE NULL END
     ) AS field,
@@ -1631,6 +1633,7 @@ WITH p AS (
             regexp_replace(btrim(replace(replace(indexdef, indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as iidx,
             COALESCE(
                 substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+                substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
             ) AS field

--- a/src/pgstac/sql/002a_queryables.sql
+++ b/src/pgstac/sql/002a_queryables.sql
@@ -259,7 +259,7 @@ CREATE OR REPLACE FUNCTION indexdef(q queryables) RETURNS text AS $$
                 q.property_path
             );
         ELSE
-            out := format($q$CREATE INDEX ON %%I USING %s (%s(((content -> 'properties'::text) -> %L::text)))$q$,
+            out := format($q$CREATE INDEX ON %%I USING %s (%s((properties -> %L::text)))$q$,
                 lower(COALESCE(q.property_index_type, 'BTREE')),
                 lower(COALESCE(q.property_wrapper, 'to_text')),
                 q.name
@@ -278,6 +278,7 @@ SELECT
     regexp_replace(btrim(replace(replace(indexdef, i.indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as idx,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
     ) AS field,
@@ -296,6 +297,7 @@ SELECT
     indexdef,
     COALESCE(
         substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+        substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
         substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_]+)''::text'),
         CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime_end_datetime' ELSE NULL END
     ) AS field,
@@ -342,6 +344,7 @@ WITH p AS (
             regexp_replace(btrim(replace(replace(indexdef, indexname, ''),'pgstac.',''),' \t\n'), '[ ]+', ' ', 'g') as iidx,
             COALESCE(
                 substring(indexdef FROM '\(([a-zA-Z0-9_]+)\)'),
+                substring(indexdef FROM 'properties -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 substring(indexdef FROM '\(content -> ''properties''::text\) -> ''([a-zA-Z0-9\:\_-]+)''::text'),
                 CASE WHEN indexdef ~* '\(datetime desc, end_datetime\)' THEN 'datetime' ELSE NULL END
             ) AS field

--- a/src/pgstac/tests/pgtap.sql
+++ b/src/pgstac/tests/pgtap.sql
@@ -17,7 +17,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 SET SEARCH_PATH TO pgstac, pgtap, public;
 
 -- Plan the tests.
-SELECT plan(371);
+SELECT plan(372);
 --SELECT * FROM no_plan();
 
 -- Run the tests.

--- a/src/pgstac/tests/pgtap/002a_queryables.sql
+++ b/src/pgstac/tests/pgtap/002a_queryables.sql
@@ -208,3 +208,11 @@ SELECT lives_ok(
 );
 
 RESET pgstac.additional_properties;
+
+SELECT results_eq(
+    $$ SELECT indexdef(q)
+       FROM queryables q
+       WHERE name = 'testqueryable'; $$,
+    $$ SELECT 'CREATE INDEX ON %I USING btree (to_text((properties -> ''testqueryable''::text)))'; $$,
+    'Managed indexes for JSON property queryables target the split properties column.'
+);


### PR DESCRIPTION
## Technical Context
- **Breaking Changes:** No

## Description

afaiu, pgstac used to store all STAC item metadata in one big JSON blob `content`, with the actual properties nested inside it at `content -> 'properties'`. At some point this was split up (#448), `properties` became its own column on the items table, and `content` went away.

But the function `indexdef()` still tries writing index commands that reached into the old, now-nonexistent `content -> 'properties'` path, and thus these fail.

This PR proposes to change that one line so it points at the real properties column directly instead of the old blob path.

`pgstac` also has to read back index definitions later (to list them, show stats, etc.), and it does that by pattern-matching the index's SQL text with a regex to pull out which property it's for. Since old indexes already created with the old pattern still exist in people's databases, the fix adds a new regex pattern for the new format alongside the old one, rather than replacing it.

---

## Checklist
- [ ] ~~**Linting:**~~  Does not apply for SQL-only change.
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [x] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [x] **Documentation:**  Added to CHANGELOG.md. No need for more documentation.
- [x] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
 ---
 > **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.