### PR TITLE
Preserve partition statistics across SQL writes, deletes, and bulk flushes

### DIFF
--- a/src/pgstac-rs/src/load/ingest.rs
+++ b/src/pgstac-rs/src/load/ingest.rs
@@ -208,9 +208,10 @@ impl ConflictPolicy {
 ///
 /// For each item: dehydrate it; for a collection with a `fragment_config`, split out the shared fragment
 /// (upserted + deduped via `ensure_fragments`) and strip the fragment-owned keys from the row; ensure its
-/// partition exists and its stats cover it (`ensure_partitions`, committed up front); then
-/// binary-COPY all rows into a session-local staging table and `flush_items_staging_binary` them into
-/// `items` resolving id collisions by `policy`. Matches `items_staging_dehydrate` for both the no-fragment
+/// partition exists and optimistically widen its stats in a committed preflight; then binary-COPY all rows
+/// into a session-local staging table and `flush_items_staging_binary` them into `items` resolving id
+/// collisions by `policy`. The flush revalidates stats and raises the row-count estimate under the partition
+/// lock in the same transaction as the item write. Matches `items_staging_dehydrate` for both the no-fragment
 /// and fragment paths. Returns the number of rows flushed. Collections must already exist.
 pub async fn load_items(
     client: &mut tokio_postgres::Client,
@@ -256,9 +257,10 @@ pub async fn load_items(
     // Create + widen every partition the batch lands in BEFORE the load. Bucket client-side
     // by (collection, partition window) and call prepare_partition_for_load once per partition — per-partition
     // metadata, O(#partitions), NOT the per-item batch-length arrays the old `ensure_partitions` shipped just
-    // to group them server-side. Each call widens dt/edt + the real SPATIAL envelope (`ensure_partitions`
-    // passed NULL) AND bumps n by this partition's staged count, so the flush writes only `items`, never
-    // partition_stats. Over-counting n is safe (ignore/upsert may insert fewer); the async tightener resets it.
+    // to group them server-side. Each call creates the partition and optimistically widens dt/edt + the real
+    // SPATIAL envelope (`ensure_partitions` passed NULL). `flush_items_staging_binary` repeats the cheap
+    // coverage guard and raises n under the same transaction/partition lock as the item write, so a tightener
+    // between preflight and flush cannot leave clean, undersized stats.
     let mut seen_collections: HashSet<&str> = HashSet::new();
     let distinct_collections: Vec<&str> = rows
         .iter()

--- a/src/pgstac/migrations/pgstac--0.9.11--unreleased.sql
+++ b/src/pgstac/migrations/pgstac--0.9.11--unreleased.sql
@@ -893,7 +893,56 @@ CREATE OR REPLACE FUNCTION pgstac.flush_items_staging_binary(_staging text, _pol
 AS $function$
 DECLARE
     nrows bigint;
+    _partition text;
+    _collection text;
+    _dtrange tstzrange;
+    _edtrange tstzrange;
+    _spatial geometry;
+    _staged_n bigint;
 BEGIN
+    FOR _collection, _dtrange, _edtrange, _spatial, _staged_n IN EXECUTE format(
+        $q$
+            WITH grouped AS (
+                SELECT
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    ) AS window_start,
+                    tstzrange(min(s.datetime), max(s.datetime), '[]') AS dtrange,
+                    tstzrange(min(s.end_datetime), max(s.end_datetime), '[]') AS edtrange,
+                    ST_SetSRID(ST_Extent(s.geometry)::geometry, 4326) AS spatial,
+                    count(*)::bigint AS staged_n
+                FROM %I s
+                JOIN pgstac.collections c ON c.id = s.collection
+                GROUP BY
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    )
+            )
+            SELECT collection, dtrange, edtrange, spatial, staged_n
+            FROM grouped
+            ORDER BY collection, window_start
+        $q$,
+        _staging
+    ) LOOP
+        _partition := pgstac.check_partition(
+            _collection,
+            _dtrange,
+            _edtrange,
+            _spatial
+        );
+
+        -- Over-counting is safe for ignore/upsert conflicts; the deferred tightener restores exact n.
+        UPDATE pgstac.partition_stats
+        SET n = COALESCE(n, 0) + _staged_n,
+            dirty = true,
+            last_updated = now()
+        WHERE partition = _partition;
+    END LOOP;
+
     IF _policy = 'ignore' THEN
         EXECUTE format('INSERT INTO items SELECT * FROM %1$I ON CONFLICT DO NOTHING', _staging);
     ELSIF _policy = 'error' THEN
@@ -1102,22 +1151,28 @@ CREATE OR REPLACE FUNCTION pgstac.items_delete_log_trigger()
  SECURITY DEFINER
 AS $function$
 BEGIN
-    INSERT INTO items_deleted_log (
-        item_id,
-        collection,
-        partition,
-        datetime,
-        end_datetime,
-        item_hash
+    WITH logged AS (
+        INSERT INTO items_deleted_log (
+            item_id,
+            collection,
+            partition,
+            datetime,
+            end_datetime,
+            item_hash
+        )
+        SELECT
+            old_rows.id,
+            old_rows.collection,
+            (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
+            old_rows.datetime,
+            old_rows.end_datetime,
+            old_rows.item_hash
+        FROM old_rows
+        RETURNING partition
     )
-    SELECT
-        old_rows.id,
-        old_rows.collection,
-        (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
-        old_rows.datetime,
-        old_rows.end_datetime,
-        old_rows.item_hash
-    FROM old_rows;
+    INSERT INTO partition_stats_delete_queue (partition)
+    SELECT DISTINCT partition
+    FROM logged;
 
     RETURN NULL;
 END;
@@ -1811,11 +1866,6 @@ BEGIN
     );
     SELECT COALESCE(n, 0) INTO pre_load_n
         FROM pgstac.partition_stats WHERE partition = partition_name;
-    -- Over-estimating n is the safe direction; the async tightener computes the exact count + extent off the
-    -- hot path. Single-row atomic UPDATE, so concurrent loads into the same partition serialize on the row.
-    UPDATE pgstac.partition_stats
-        SET n = COALESCE(n, 0) + _n_add, dirty = true, last_updated = now()
-        WHERE partition = partition_name;
 END;
 $function$
 ;
@@ -2545,10 +2595,21 @@ DECLARE
     _count int := 0;
 BEGIN
     FOR _part IN
-        SELECT partition FROM pgstac.partition_stats
-        WHERE dirty
-        ORDER BY last_updated NULLS FIRST
-        LIMIT _limit
+        SELECT candidate.partition
+        FROM (
+            SELECT ps.partition, ps.collection
+            FROM pgstac.partition_stats ps
+            WHERE
+                ps.dirty
+                OR EXISTS (
+                    SELECT 1
+                    FROM pgstac.partition_stats_delete_queue q
+                    WHERE q.partition = ps.partition
+                )
+            ORDER BY ps.last_updated NULLS FIRST
+            LIMIT _limit
+        ) candidate
+        ORDER BY candidate.collection, candidate.partition
     LOOP
         PERFORM pgstac.tighten_partition_stats(_part);
         _count := _count + 1;
@@ -2577,6 +2638,12 @@ BEGIN
     -- extent would be left uncovered (search would prune + miss it). Same lock check_partition uses, so
     -- tighten serializes with ingest into this partition only.
     PERFORM pg_advisory_xact_lock(hashtext('pgstac.check_partition'), hashtext(_partition));
+
+    -- Acknowledge only DELETE work visible before the exact scan. Each concurrent DELETE appends an
+    -- independent row, so one that commits after this statement remains pending for the next sweep. If
+    -- the scan or stats write fails, this DELETE rolls back with the rest of the transaction.
+    DELETE FROM partition_stats_delete_queue
+    WHERE partition = _partition;
 
     EXECUTE format(
         $q$
@@ -2867,7 +2934,8 @@ BEGIN
 
     dt_covered  := COALESCE(cur.dtrange  @> _dtrange,  false);
     edt_covered := COALESCE(cur.edtrange @> _edtrange, false);
-    spatial_covered := cur.spatial IS NULL OR _spatial IS NULL OR ST_Covers(cur.spatial, _spatial);
+    spatial_covered := cur.spatial IS NULL
+        OR (_spatial IS NOT NULL AND ST_Covers(cur.spatial, _spatial));
     IF dt_covered AND edt_covered AND spatial_covered THEN
         RETURN; -- already covered: no write, no lock
     END IF;
@@ -3180,12 +3248,17 @@ DECLARE
     collection_base_partition text := concat('_items_', OLD.key);
 BEGIN
     EXECUTE format($q$
+        DELETE FROM partition_stats_delete_queue WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
         DELETE FROM partition_stats WHERE partition IN (
             SELECT partition FROM partition_sys_meta
             WHERE collection=%L
         );
         DROP TABLE IF EXISTS %I CASCADE;
         $q$,
+        OLD.id,
         OLD.id,
         collection_base_partition
     );
@@ -4368,7 +4441,9 @@ BEGIN
             tstzrange(min(upper(dtr)),max(upper(dtr)),'[]') as edtrange
         FROM t
         GROUP BY 1,2
-    ) SELECT check_partition(collection, dtrange, edtrange) FROM p LOOP
+    ) SELECT check_partition(collection, dtrange, edtrange)
+      FROM p
+      ORDER BY collection, d LOOP
         RAISE NOTICE 'Partition %', part;
     END LOOP;
 
@@ -5933,6 +6008,11 @@ create table "pgstac"."items_deleted_log" (
 );
 
 
+create table "pgstac"."partition_stats_delete_queue" (
+    "partition" text not null
+);
+
+
 alter table "pgstac"."collections" drop column "base_item";
 
 alter table "pgstac"."collections" add column "fragment_config" text[];
@@ -6130,8 +6210,6 @@ drop function if exists "pgstac"."upsert_collection"(data jsonb);
 
 drop function if exists "pgstac"."where_stats"(inwhere text, updatestats boolean, conf jsonb);
 
-drop function if exists "pgstac"."parse_dtrange"(_indate text, relative_base timestamp with time zone);
-
 create or replace view "pgstac"."collections_asitems" as  SELECT id,
     geometry,
     'collections'::text AS collection,
@@ -6259,6 +6337,8 @@ CREATE INDEX items_fragment_id_idx ON ONLY pgstac.items USING btree (fragment_id
 
 CREATE INDEX partition_stats_collection_idx ON pgstac.partition_stats USING btree (collection);
 
+CREATE INDEX partition_stats_delete_queue_partition_idx ON pgstac.partition_stats_delete_queue USING btree (partition);
+
 CREATE INDEX partition_stats_dirty_idx ON pgstac.partition_stats USING btree (partition) WHERE dirty;
 
 CREATE INDEX partition_stats_indexes_pending_idx ON pgstac.partition_stats USING btree (partition) WHERE indexes_pending;
@@ -6282,6 +6362,33 @@ alter table "pgstac"."item_fragments" add constraint "item_fragments_collection_
 alter table "pgstac"."item_fragments" validate constraint "item_fragments_collection_fkey";
 
 alter table "pgstac"."item_fragments" add constraint "item_fragments_collection_hash_key" UNIQUE using index "item_fragments_collection_hash_key";
+
+CREATE OR REPLACE FUNCTION pgstac.collection_delete_trigger_func()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    collection_base_partition text := concat('_items_', OLD.key);
+BEGIN
+    EXECUTE format($q$
+        DELETE FROM partition_stats_delete_queue WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
+        DELETE FROM partition_stats WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
+        DROP TABLE IF EXISTS %I CASCADE;
+        $q$,
+        OLD.id,
+        OLD.id,
+        collection_base_partition
+    );
+    RETURN OLD;
+END;
+$function$
+;
 
 CREATE OR REPLACE FUNCTION pgstac.collection_extent(_collection text, runupdate boolean DEFAULT false)
  RETURNS jsonb
@@ -6965,7 +7072,9 @@ BEGIN
             tstzrange(min(upper(dtr)),max(upper(dtr)),'[]') as edtrange
         FROM t
         GROUP BY 1,2
-    ) SELECT check_partition(collection, dtrange, edtrange) FROM p LOOP
+    ) SELECT check_partition(collection, dtrange, edtrange)
+      FROM p
+      ORDER BY collection, d LOOP
         RAISE NOTICE 'Partition %', part;
     END LOOP;
 
@@ -7581,7 +7690,12 @@ GRANT USAGE ON ALL SEQUENCES IN SCHEMA pgstac to pgstac_ingest;
 -- envelope-narrowing direct write structurally impossible. New partitions are created SELECT-only for
 -- pgstac_ingest by check_partition; the items parent is revoked here. Staging tables (items_staging*) stay
 -- writable so the SQL-only ingest path can COPY into them.
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON items, partition_stats, item_fragments FROM pgstac_ingest;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON
+    items,
+    partition_stats,
+    partition_stats_delete_queue,
+    item_fragments
+FROM pgstac_ingest;
 -- item_field_registry is the one exception to the wall: the loader WIDENS it directly with an add-only
 -- INSERT ... ON CONFLICT DO UPDATE (no SD function), so INSERT + UPDATE stay granted. DELETE/TRUNCATE remain
 -- revoked, so even a direct write cannot NARROW the registry — INV-1 (registry is a superset of the data)

--- a/src/pgstac/migrations/pgstac--unreleased.sql
+++ b/src/pgstac/migrations/pgstac--unreleased.sql
@@ -1268,12 +1268,17 @@ DECLARE
     collection_base_partition text := concat('_items_', OLD.key);
 BEGIN
     EXECUTE format($q$
+        DELETE FROM partition_stats_delete_queue WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
         DELETE FROM partition_stats WHERE partition IN (
             SELECT partition FROM partition_sys_meta
             WHERE collection=%L
         );
         DROP TABLE IF EXISTS %I CASCADE;
         $q$,
+        OLD.id,
         OLD.id,
         collection_base_partition
     );
@@ -3086,6 +3091,17 @@ CREATE TABLE IF NOT EXISTS items_deleted_log (
 );
 CREATE INDEX IF NOT EXISTS items_deleted_log_deleted_at_idx ON items_deleted_log (deleted_at);
 
+-- Append-only work queue for partitions whose exact stats may have become too
+-- wide after DELETE. Keep this separate from partition_stats: the AFTER DELETE
+-- trigger already holds item-row locks, so updating/locking partition_stats
+-- here would invert the check_partition lock order used by ingest. Tightening
+-- captures and removes only queue rows visible before its exact table scan.
+CREATE TABLE IF NOT EXISTS partition_stats_delete_queue (
+    partition text NOT NULL
+);
+CREATE INDEX IF NOT EXISTS partition_stats_delete_queue_partition_idx
+    ON partition_stats_delete_queue (partition);
+
 -- Field registry: tracks which JSON paths exist in each collection (for queryables)
 CREATE TABLE IF NOT EXISTS item_field_registry (
     collection text NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
@@ -3190,22 +3206,28 @@ EXECUTE FUNCTION items_touch_triggerfunc();
 
 CREATE OR REPLACE FUNCTION items_delete_log_trigger() RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO items_deleted_log (
-        item_id,
-        collection,
-        partition,
-        datetime,
-        end_datetime,
-        item_hash
+    WITH logged AS (
+        INSERT INTO items_deleted_log (
+            item_id,
+            collection,
+            partition,
+            datetime,
+            end_datetime,
+            item_hash
+        )
+        SELECT
+            old_rows.id,
+            old_rows.collection,
+            (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
+            old_rows.datetime,
+            old_rows.end_datetime,
+            old_rows.item_hash
+        FROM old_rows
+        RETURNING partition
     )
-    SELECT
-        old_rows.id,
-        old_rows.collection,
-        (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
-        old_rows.datetime,
-        old_rows.end_datetime,
-        old_rows.item_hash
-    FROM old_rows;
+    INSERT INTO partition_stats_delete_queue (partition)
+    SELECT DISTINCT partition
+    FROM logged;
 
     RETURN NULL;
 END;
@@ -3746,7 +3768,9 @@ BEGIN
             tstzrange(min(upper(dtr)),max(upper(dtr)),'[]') as edtrange
         FROM t
         GROUP BY 1,2
-    ) SELECT check_partition(collection, dtrange, edtrange) FROM p LOOP
+    ) SELECT check_partition(collection, dtrange, edtrange)
+      FROM p
+      ORDER BY collection, d LOOP
         RAISE NOTICE 'Partition %', part;
     END LOOP;
 
@@ -4220,8 +4244,8 @@ $$ LANGUAGE PLPGSQL STABLE;
 --                   that can land there); a NULL-partition_trunc partition pads the batch range by
 --                   partition_stats_widen_buffer (default 1 month) each side.
 --   * end_datetime: the datetime target extended by the batch's max (end_datetime - datetime) tail.
---   * spatial     : NULL means "always a search candidate"; a spatial miss resets spatial to NULL until
---                   the tightener computes the real extent.
+--   * spatial     : an unknown batch extent or a spatial miss resets spatial to NULL ("always a search
+--                   candidate") until the tightener computes the real extent.
 -- Requires the partition_stats row to exist (check_partition seeds it); raises if it does not.
 CREATE OR REPLACE FUNCTION widen_partition_stats(
     _partition text,
@@ -4253,7 +4277,8 @@ BEGIN
 
     dt_covered  := COALESCE(cur.dtrange  @> _dtrange,  false);
     edt_covered := COALESCE(cur.edtrange @> _edtrange, false);
-    spatial_covered := cur.spatial IS NULL OR _spatial IS NULL OR ST_Covers(cur.spatial, _spatial);
+    spatial_covered := cur.spatial IS NULL
+        OR (_spatial IS NOT NULL AND ST_Covers(cur.spatial, _spatial));
     IF dt_covered AND edt_covered AND spatial_covered THEN
         RETURN; -- already covered: no write, no lock
     END IF;
@@ -4590,12 +4615,12 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- prepare_partition_for_load: per-partition metadata for the Rust direct / precheck load paths. ONE small
--- self-contained txn per partition, run BEFORE any COPY: create + widen the partition to cover this batch
--- (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL) and bump n, so
--- partition_stats is at least as wide as the data (golden rule) and search treats the partition as non-empty
--- before the data lands. Returns the partition name + the pre-load row count (n BEFORE the bump) so the
--- loader can choose its adaptive precheck path: empty -> skip the precheck; batch > n -> pull the partition's
--- (id,item_hash) to the client; n >= batch -> COPY the batch (id,hash) to a temp table + JOIN this partition.
+-- self-contained txn per partition, run BEFORE any COPY: create + optimistically widen the partition to
+-- cover this batch (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL).
+-- Returns the partition name + pre-load row count for adaptive duplicate prechecks. `_n_add` remains in the
+-- stable function signature, but the count update happens in flush_items_staging_binary: moving it into the
+-- same transaction as the item write prevents an intervening tightener from replacing it with an old exact
+-- count. The flush also revalidates the envelope and holds the partition lock through commit.
 CREATE OR REPLACE FUNCTION prepare_partition_for_load(
     _collection text,
     _dt_lo timestamptz, _dt_hi timestamptz,
@@ -4614,11 +4639,6 @@ BEGIN
     );
     SELECT COALESCE(n, 0) INTO pre_load_n
         FROM pgstac.partition_stats WHERE partition = partition_name;
-    -- Over-estimating n is the safe direction; the async tightener computes the exact count + extent off the
-    -- hot path. Single-row atomic UPDATE, so concurrent loads into the same partition serialize on the row.
-    UPDATE pgstac.partition_stats
-        SET n = COALESCE(n, 0) + _n_add, dirty = true, last_updated = now()
-        WHERE partition = partition_name;
 END;
 $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
@@ -4639,8 +4659,11 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- flush_items_staging_binary: move fully-dehydrated rows from a TEMP staging table into `items` with the
--- conflict policy. partition_stats (extent + n + dirty) is set entirely by prepare_partition_for_load in
--- the preflight, so this writes only `items`:
+-- conflict policy. Before touching items, aggregate the staged partitions, re-check/widen their metadata,
+-- and raise n while holding each partition advisory lock through commit. This closes the transaction gap
+-- between prepare_partition_for_load and flush: a tightener may run during COPY, but cannot run after this
+-- recheck and before the items become visible. Locks are acquired in the same collection/window order as
+-- ensure_partitions and the SQL staging path:
 --        ignore  -> ON CONFLICT DO NOTHING (idempotent; orphans the old row on a cross-partition move)
 --        upsert  -> delete a changed row IN THE PARTITION IT ROUTES TO (window-pruned), then insert. A
 --                   datetime change that stays in the partition is applied; one that moves the item to a
@@ -4654,7 +4677,56 @@ CREATE OR REPLACE FUNCTION flush_items_staging_binary(
 ) RETURNS bigint AS $$
 DECLARE
     nrows bigint;
+    _partition text;
+    _collection text;
+    _dtrange tstzrange;
+    _edtrange tstzrange;
+    _spatial geometry;
+    _staged_n bigint;
 BEGIN
+    FOR _collection, _dtrange, _edtrange, _spatial, _staged_n IN EXECUTE format(
+        $q$
+            WITH grouped AS (
+                SELECT
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    ) AS window_start,
+                    tstzrange(min(s.datetime), max(s.datetime), '[]') AS dtrange,
+                    tstzrange(min(s.end_datetime), max(s.end_datetime), '[]') AS edtrange,
+                    ST_SetSRID(ST_Extent(s.geometry)::geometry, 4326) AS spatial,
+                    count(*)::bigint AS staged_n
+                FROM %I s
+                JOIN pgstac.collections c ON c.id = s.collection
+                GROUP BY
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    )
+            )
+            SELECT collection, dtrange, edtrange, spatial, staged_n
+            FROM grouped
+            ORDER BY collection, window_start
+        $q$,
+        _staging
+    ) LOOP
+        _partition := pgstac.check_partition(
+            _collection,
+            _dtrange,
+            _edtrange,
+            _spatial
+        );
+
+        -- Over-counting is safe for ignore/upsert conflicts; the deferred tightener restores exact n.
+        UPDATE pgstac.partition_stats
+        SET n = COALESCE(n, 0) + _staged_n,
+            dirty = true,
+            last_updated = now()
+        WHERE partition = _partition;
+    END LOOP;
+
     IF _policy = 'ignore' THEN
         EXECUTE format('INSERT INTO items SELECT * FROM %1$I ON CONFLICT DO NOTHING', _staging);
     ELSIF _policy = 'error' THEN
@@ -5634,10 +5706,12 @@ $$ LANGUAGE SQL;
 
 -- BEGIN FRAGMENT: 997_maintenance.sql
 
--- tighten_dirty_partition_stats: recompute the exact envelope + row count for dirty partitions (oldest
--- first), clearing dirty. Run off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only
--- over-includes a partition in search, so skipping it never loses rows. `_limit` caps the batch (NULL =
--- all dirty); returns the number of partitions tightened.
+-- tighten_dirty_partition_stats: recompute the exact envelope + row count for partitions widened by
+-- ingest or queued by DELETE. Choose the oldest `_limit` candidates, then acquire their advisory locks in
+-- collection/partition order so concurrent multi-partition ingest follows the same lock order. Run
+-- off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only over-includes a partition in
+-- search, so skipping it never loses rows. `_limit` caps the batch (NULL = all pending); returns the number
+-- of partitions tightened.
 --
 -- pg_cron example (operators install this themselves):
 --   SELECT cron.schedule('pgstac-tighten', '*/15 * * * *',
@@ -5649,10 +5723,21 @@ DECLARE
     _count int := 0;
 BEGIN
     FOR _part IN
-        SELECT partition FROM pgstac.partition_stats
-        WHERE dirty
-        ORDER BY last_updated NULLS FIRST
-        LIMIT _limit
+        SELECT candidate.partition
+        FROM (
+            SELECT ps.partition, ps.collection
+            FROM pgstac.partition_stats ps
+            WHERE
+                ps.dirty
+                OR EXISTS (
+                    SELECT 1
+                    FROM pgstac.partition_stats_delete_queue q
+                    WHERE q.partition = ps.partition
+                )
+            ORDER BY ps.last_updated NULLS FIRST
+            LIMIT _limit
+        ) candidate
+        ORDER BY candidate.collection, candidate.partition
     LOOP
         PERFORM pgstac.tighten_partition_stats(_part);
         _count := _count + 1;
@@ -6043,6 +6128,12 @@ BEGIN
     -- tighten serializes with ingest into this partition only.
     PERFORM pg_advisory_xact_lock(hashtext('pgstac.check_partition'), hashtext(_partition));
 
+    -- Acknowledge only DELETE work visible before the exact scan. Each concurrent DELETE appends an
+    -- independent row, so one that commits after this statement remains pending for the next sweep. If
+    -- the scan or stats write fails, this DELETE rolls back with the rest of the transaction.
+    DELETE FROM partition_stats_delete_queue
+    WHERE partition = _partition;
+
     EXECUTE format(
         $q$
             SELECT count(*), min(datetime), max(datetime), min(end_datetime), max(end_datetime),
@@ -6240,7 +6331,12 @@ GRANT USAGE ON ALL SEQUENCES IN SCHEMA pgstac to pgstac_ingest;
 -- envelope-narrowing direct write structurally impossible. New partitions are created SELECT-only for
 -- pgstac_ingest by check_partition; the items parent is revoked here. Staging tables (items_staging*) stay
 -- writable so the SQL-only ingest path can COPY into them.
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON items, partition_stats, item_fragments FROM pgstac_ingest;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON
+    items,
+    partition_stats,
+    partition_stats_delete_queue,
+    item_fragments
+FROM pgstac_ingest;
 -- item_field_registry is the one exception to the wall: the loader WIDENS it directly with an add-only
 -- INSERT ... ON CONFLICT DO UPDATE (no SD function), so INSERT + UPDATE stay granted. DELETE/TRUNCATE remain
 -- revoked, so even a direct write cannot NARROW the registry — INV-1 (registry is a superset of the data)

--- a/src/pgstac/pgstac.sql
+++ b/src/pgstac/pgstac.sql
@@ -1268,12 +1268,17 @@ DECLARE
     collection_base_partition text := concat('_items_', OLD.key);
 BEGIN
     EXECUTE format($q$
+        DELETE FROM partition_stats_delete_queue WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
         DELETE FROM partition_stats WHERE partition IN (
             SELECT partition FROM partition_sys_meta
             WHERE collection=%L
         );
         DROP TABLE IF EXISTS %I CASCADE;
         $q$,
+        OLD.id,
         OLD.id,
         collection_base_partition
     );
@@ -3086,6 +3091,17 @@ CREATE TABLE IF NOT EXISTS items_deleted_log (
 );
 CREATE INDEX IF NOT EXISTS items_deleted_log_deleted_at_idx ON items_deleted_log (deleted_at);
 
+-- Append-only work queue for partitions whose exact stats may have become too
+-- wide after DELETE. Keep this separate from partition_stats: the AFTER DELETE
+-- trigger already holds item-row locks, so updating/locking partition_stats
+-- here would invert the check_partition lock order used by ingest. Tightening
+-- captures and removes only queue rows visible before its exact table scan.
+CREATE TABLE IF NOT EXISTS partition_stats_delete_queue (
+    partition text NOT NULL
+);
+CREATE INDEX IF NOT EXISTS partition_stats_delete_queue_partition_idx
+    ON partition_stats_delete_queue (partition);
+
 -- Field registry: tracks which JSON paths exist in each collection (for queryables)
 CREATE TABLE IF NOT EXISTS item_field_registry (
     collection text NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
@@ -3190,22 +3206,28 @@ EXECUTE FUNCTION items_touch_triggerfunc();
 
 CREATE OR REPLACE FUNCTION items_delete_log_trigger() RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO items_deleted_log (
-        item_id,
-        collection,
-        partition,
-        datetime,
-        end_datetime,
-        item_hash
+    WITH logged AS (
+        INSERT INTO items_deleted_log (
+            item_id,
+            collection,
+            partition,
+            datetime,
+            end_datetime,
+            item_hash
+        )
+        SELECT
+            old_rows.id,
+            old_rows.collection,
+            (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
+            old_rows.datetime,
+            old_rows.end_datetime,
+            old_rows.item_hash
+        FROM old_rows
+        RETURNING partition
     )
-    SELECT
-        old_rows.id,
-        old_rows.collection,
-        (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
-        old_rows.datetime,
-        old_rows.end_datetime,
-        old_rows.item_hash
-    FROM old_rows;
+    INSERT INTO partition_stats_delete_queue (partition)
+    SELECT DISTINCT partition
+    FROM logged;
 
     RETURN NULL;
 END;
@@ -3746,7 +3768,9 @@ BEGIN
             tstzrange(min(upper(dtr)),max(upper(dtr)),'[]') as edtrange
         FROM t
         GROUP BY 1,2
-    ) SELECT check_partition(collection, dtrange, edtrange) FROM p LOOP
+    ) SELECT check_partition(collection, dtrange, edtrange)
+      FROM p
+      ORDER BY collection, d LOOP
         RAISE NOTICE 'Partition %', part;
     END LOOP;
 
@@ -4220,8 +4244,8 @@ $$ LANGUAGE PLPGSQL STABLE;
 --                   that can land there); a NULL-partition_trunc partition pads the batch range by
 --                   partition_stats_widen_buffer (default 1 month) each side.
 --   * end_datetime: the datetime target extended by the batch's max (end_datetime - datetime) tail.
---   * spatial     : NULL means "always a search candidate"; a spatial miss resets spatial to NULL until
---                   the tightener computes the real extent.
+--   * spatial     : an unknown batch extent or a spatial miss resets spatial to NULL ("always a search
+--                   candidate") until the tightener computes the real extent.
 -- Requires the partition_stats row to exist (check_partition seeds it); raises if it does not.
 CREATE OR REPLACE FUNCTION widen_partition_stats(
     _partition text,
@@ -4253,7 +4277,8 @@ BEGIN
 
     dt_covered  := COALESCE(cur.dtrange  @> _dtrange,  false);
     edt_covered := COALESCE(cur.edtrange @> _edtrange, false);
-    spatial_covered := cur.spatial IS NULL OR _spatial IS NULL OR ST_Covers(cur.spatial, _spatial);
+    spatial_covered := cur.spatial IS NULL
+        OR (_spatial IS NOT NULL AND ST_Covers(cur.spatial, _spatial));
     IF dt_covered AND edt_covered AND spatial_covered THEN
         RETURN; -- already covered: no write, no lock
     END IF;
@@ -4590,12 +4615,12 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- prepare_partition_for_load: per-partition metadata for the Rust direct / precheck load paths. ONE small
--- self-contained txn per partition, run BEFORE any COPY: create + widen the partition to cover this batch
--- (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL) and bump n, so
--- partition_stats is at least as wide as the data (golden rule) and search treats the partition as non-empty
--- before the data lands. Returns the partition name + the pre-load row count (n BEFORE the bump) so the
--- loader can choose its adaptive precheck path: empty -> skip the precheck; batch > n -> pull the partition's
--- (id,item_hash) to the client; n >= batch -> COPY the batch (id,hash) to a temp table + JOIN this partition.
+-- self-contained txn per partition, run BEFORE any COPY: create + optimistically widen the partition to
+-- cover this batch (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL).
+-- Returns the partition name + pre-load row count for adaptive duplicate prechecks. `_n_add` remains in the
+-- stable function signature, but the count update happens in flush_items_staging_binary: moving it into the
+-- same transaction as the item write prevents an intervening tightener from replacing it with an old exact
+-- count. The flush also revalidates the envelope and holds the partition lock through commit.
 CREATE OR REPLACE FUNCTION prepare_partition_for_load(
     _collection text,
     _dt_lo timestamptz, _dt_hi timestamptz,
@@ -4614,11 +4639,6 @@ BEGIN
     );
     SELECT COALESCE(n, 0) INTO pre_load_n
         FROM pgstac.partition_stats WHERE partition = partition_name;
-    -- Over-estimating n is the safe direction; the async tightener computes the exact count + extent off the
-    -- hot path. Single-row atomic UPDATE, so concurrent loads into the same partition serialize on the row.
-    UPDATE pgstac.partition_stats
-        SET n = COALESCE(n, 0) + _n_add, dirty = true, last_updated = now()
-        WHERE partition = partition_name;
 END;
 $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
@@ -4639,8 +4659,11 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- flush_items_staging_binary: move fully-dehydrated rows from a TEMP staging table into `items` with the
--- conflict policy. partition_stats (extent + n + dirty) is set entirely by prepare_partition_for_load in
--- the preflight, so this writes only `items`:
+-- conflict policy. Before touching items, aggregate the staged partitions, re-check/widen their metadata,
+-- and raise n while holding each partition advisory lock through commit. This closes the transaction gap
+-- between prepare_partition_for_load and flush: a tightener may run during COPY, but cannot run after this
+-- recheck and before the items become visible. Locks are acquired in the same collection/window order as
+-- ensure_partitions and the SQL staging path:
 --        ignore  -> ON CONFLICT DO NOTHING (idempotent; orphans the old row on a cross-partition move)
 --        upsert  -> delete a changed row IN THE PARTITION IT ROUTES TO (window-pruned), then insert. A
 --                   datetime change that stays in the partition is applied; one that moves the item to a
@@ -4654,7 +4677,56 @@ CREATE OR REPLACE FUNCTION flush_items_staging_binary(
 ) RETURNS bigint AS $$
 DECLARE
     nrows bigint;
+    _partition text;
+    _collection text;
+    _dtrange tstzrange;
+    _edtrange tstzrange;
+    _spatial geometry;
+    _staged_n bigint;
 BEGIN
+    FOR _collection, _dtrange, _edtrange, _spatial, _staged_n IN EXECUTE format(
+        $q$
+            WITH grouped AS (
+                SELECT
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    ) AS window_start,
+                    tstzrange(min(s.datetime), max(s.datetime), '[]') AS dtrange,
+                    tstzrange(min(s.end_datetime), max(s.end_datetime), '[]') AS edtrange,
+                    ST_SetSRID(ST_Extent(s.geometry)::geometry, 4326) AS spatial,
+                    count(*)::bigint AS staged_n
+                FROM %I s
+                JOIN pgstac.collections c ON c.id = s.collection
+                GROUP BY
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    )
+            )
+            SELECT collection, dtrange, edtrange, spatial, staged_n
+            FROM grouped
+            ORDER BY collection, window_start
+        $q$,
+        _staging
+    ) LOOP
+        _partition := pgstac.check_partition(
+            _collection,
+            _dtrange,
+            _edtrange,
+            _spatial
+        );
+
+        -- Over-counting is safe for ignore/upsert conflicts; the deferred tightener restores exact n.
+        UPDATE pgstac.partition_stats
+        SET n = COALESCE(n, 0) + _staged_n,
+            dirty = true,
+            last_updated = now()
+        WHERE partition = _partition;
+    END LOOP;
+
     IF _policy = 'ignore' THEN
         EXECUTE format('INSERT INTO items SELECT * FROM %1$I ON CONFLICT DO NOTHING', _staging);
     ELSIF _policy = 'error' THEN
@@ -5634,10 +5706,12 @@ $$ LANGUAGE SQL;
 
 -- BEGIN FRAGMENT: 997_maintenance.sql
 
--- tighten_dirty_partition_stats: recompute the exact envelope + row count for dirty partitions (oldest
--- first), clearing dirty. Run off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only
--- over-includes a partition in search, so skipping it never loses rows. `_limit` caps the batch (NULL =
--- all dirty); returns the number of partitions tightened.
+-- tighten_dirty_partition_stats: recompute the exact envelope + row count for partitions widened by
+-- ingest or queued by DELETE. Choose the oldest `_limit` candidates, then acquire their advisory locks in
+-- collection/partition order so concurrent multi-partition ingest follows the same lock order. Run
+-- off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only over-includes a partition in
+-- search, so skipping it never loses rows. `_limit` caps the batch (NULL = all pending); returns the number
+-- of partitions tightened.
 --
 -- pg_cron example (operators install this themselves):
 --   SELECT cron.schedule('pgstac-tighten', '*/15 * * * *',
@@ -5649,10 +5723,21 @@ DECLARE
     _count int := 0;
 BEGIN
     FOR _part IN
-        SELECT partition FROM pgstac.partition_stats
-        WHERE dirty
-        ORDER BY last_updated NULLS FIRST
-        LIMIT _limit
+        SELECT candidate.partition
+        FROM (
+            SELECT ps.partition, ps.collection
+            FROM pgstac.partition_stats ps
+            WHERE
+                ps.dirty
+                OR EXISTS (
+                    SELECT 1
+                    FROM pgstac.partition_stats_delete_queue q
+                    WHERE q.partition = ps.partition
+                )
+            ORDER BY ps.last_updated NULLS FIRST
+            LIMIT _limit
+        ) candidate
+        ORDER BY candidate.collection, candidate.partition
     LOOP
         PERFORM pgstac.tighten_partition_stats(_part);
         _count := _count + 1;
@@ -6043,6 +6128,12 @@ BEGIN
     -- tighten serializes with ingest into this partition only.
     PERFORM pg_advisory_xact_lock(hashtext('pgstac.check_partition'), hashtext(_partition));
 
+    -- Acknowledge only DELETE work visible before the exact scan. Each concurrent DELETE appends an
+    -- independent row, so one that commits after this statement remains pending for the next sweep. If
+    -- the scan or stats write fails, this DELETE rolls back with the rest of the transaction.
+    DELETE FROM partition_stats_delete_queue
+    WHERE partition = _partition;
+
     EXECUTE format(
         $q$
             SELECT count(*), min(datetime), max(datetime), min(end_datetime), max(end_datetime),
@@ -6240,7 +6331,12 @@ GRANT USAGE ON ALL SEQUENCES IN SCHEMA pgstac to pgstac_ingest;
 -- envelope-narrowing direct write structurally impossible. New partitions are created SELECT-only for
 -- pgstac_ingest by check_partition; the items parent is revoked here. Staging tables (items_staging*) stay
 -- writable so the SQL-only ingest path can COPY into them.
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON items, partition_stats, item_fragments FROM pgstac_ingest;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON
+    items,
+    partition_stats,
+    partition_stats_delete_queue,
+    item_fragments
+FROM pgstac_ingest;
 -- item_field_registry is the one exception to the wall: the loader WIDENS it directly with an add-only
 -- INSERT ... ON CONFLICT DO UPDATE (no SD function), so INSERT + UPDATE stay granted. DELETE/TRUNCATE remain
 -- revoked, so even a direct write cannot NARROW the registry — INV-1 (registry is a superset of the data)

--- a/src/pgstac/sql/002_collections.sql
+++ b/src/pgstac/sql/002_collections.sql
@@ -163,12 +163,17 @@ DECLARE
     collection_base_partition text := concat('_items_', OLD.key);
 BEGIN
     EXECUTE format($q$
+        DELETE FROM partition_stats_delete_queue WHERE partition IN (
+            SELECT partition FROM partition_sys_meta
+            WHERE collection=%L
+        );
         DELETE FROM partition_stats WHERE partition IN (
             SELECT partition FROM partition_sys_meta
             WHERE collection=%L
         );
         DROP TABLE IF EXISTS %I CASCADE;
         $q$,
+        OLD.id,
         OLD.id,
         collection_base_partition
     );

--- a/src/pgstac/sql/003a_items.sql
+++ b/src/pgstac/sql/003a_items.sql
@@ -112,6 +112,17 @@ CREATE TABLE IF NOT EXISTS items_deleted_log (
 );
 CREATE INDEX IF NOT EXISTS items_deleted_log_deleted_at_idx ON items_deleted_log (deleted_at);
 
+-- Append-only work queue for partitions whose exact stats may have become too
+-- wide after DELETE. Keep this separate from partition_stats: the AFTER DELETE
+-- trigger already holds item-row locks, so updating/locking partition_stats
+-- here would invert the check_partition lock order used by ingest. Tightening
+-- captures and removes only queue rows visible before its exact table scan.
+CREATE TABLE IF NOT EXISTS partition_stats_delete_queue (
+    partition text NOT NULL
+);
+CREATE INDEX IF NOT EXISTS partition_stats_delete_queue_partition_idx
+    ON partition_stats_delete_queue (partition);
+
 -- Field registry: tracks which JSON paths exist in each collection (for queryables)
 CREATE TABLE IF NOT EXISTS item_field_registry (
     collection text NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
@@ -216,22 +227,28 @@ EXECUTE FUNCTION items_touch_triggerfunc();
 
 CREATE OR REPLACE FUNCTION items_delete_log_trigger() RETURNS TRIGGER AS $$
 BEGIN
-    INSERT INTO items_deleted_log (
-        item_id,
-        collection,
-        partition,
-        datetime,
-        end_datetime,
-        item_hash
+    WITH logged AS (
+        INSERT INTO items_deleted_log (
+            item_id,
+            collection,
+            partition,
+            datetime,
+            end_datetime,
+            item_hash
+        )
+        SELECT
+            old_rows.id,
+            old_rows.collection,
+            (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
+            old_rows.datetime,
+            old_rows.end_datetime,
+            old_rows.item_hash
+        FROM old_rows
+        RETURNING partition
     )
-    SELECT
-        old_rows.id,
-        old_rows.collection,
-        (partition_name(old_rows.collection, old_rows.datetime)).partition_name,
-        old_rows.datetime,
-        old_rows.end_datetime,
-        old_rows.item_hash
-    FROM old_rows;
+    INSERT INTO partition_stats_delete_queue (partition)
+    SELECT DISTINCT partition
+    FROM logged;
 
     RETURN NULL;
 END;
@@ -772,7 +789,9 @@ BEGIN
             tstzrange(min(upper(dtr)),max(upper(dtr)),'[]') as edtrange
         FROM t
         GROUP BY 1,2
-    ) SELECT check_partition(collection, dtrange, edtrange) FROM p LOOP
+    ) SELECT check_partition(collection, dtrange, edtrange)
+      FROM p
+      ORDER BY collection, d LOOP
         RAISE NOTICE 'Partition %', part;
     END LOOP;
 

--- a/src/pgstac/sql/003b_partitions.sql
+++ b/src/pgstac/sql/003b_partitions.sql
@@ -218,8 +218,8 @@ $$ LANGUAGE PLPGSQL STABLE;
 --                   that can land there); a NULL-partition_trunc partition pads the batch range by
 --                   partition_stats_widen_buffer (default 1 month) each side.
 --   * end_datetime: the datetime target extended by the batch's max (end_datetime - datetime) tail.
---   * spatial     : NULL means "always a search candidate"; a spatial miss resets spatial to NULL until
---                   the tightener computes the real extent.
+--   * spatial     : an unknown batch extent or a spatial miss resets spatial to NULL ("always a search
+--                   candidate") until the tightener computes the real extent.
 -- Requires the partition_stats row to exist (check_partition seeds it); raises if it does not.
 CREATE OR REPLACE FUNCTION widen_partition_stats(
     _partition text,
@@ -251,7 +251,8 @@ BEGIN
 
     dt_covered  := COALESCE(cur.dtrange  @> _dtrange,  false);
     edt_covered := COALESCE(cur.edtrange @> _edtrange, false);
-    spatial_covered := cur.spatial IS NULL OR _spatial IS NULL OR ST_Covers(cur.spatial, _spatial);
+    spatial_covered := cur.spatial IS NULL
+        OR (_spatial IS NOT NULL AND ST_Covers(cur.spatial, _spatial));
     IF dt_covered AND edt_covered AND spatial_covered THEN
         RETURN; -- already covered: no write, no lock
     END IF;

--- a/src/pgstac/sql/003c_ingest.sql
+++ b/src/pgstac/sql/003c_ingest.sql
@@ -107,12 +107,12 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- prepare_partition_for_load: per-partition metadata for the Rust direct / precheck load paths. ONE small
--- self-contained txn per partition, run BEFORE any COPY: create + widen the partition to cover this batch
--- (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL) and bump n, so
--- partition_stats is at least as wide as the data (golden rule) and search treats the partition as non-empty
--- before the data lands. Returns the partition name + the pre-load row count (n BEFORE the bump) so the
--- loader can choose its adaptive precheck path: empty -> skip the precheck; batch > n -> pull the partition's
--- (id,item_hash) to the client; n >= batch -> COPY the batch (id,hash) to a temp table + JOIN this partition.
+-- self-contained txn per partition, run BEFORE any COPY: create + optimistically widen the partition to
+-- cover this batch (dt + edt + the real SPATIAL envelope, unlike ensure_partitions which passes NULL).
+-- Returns the partition name + pre-load row count for adaptive duplicate prechecks. `_n_add` remains in the
+-- stable function signature, but the count update happens in flush_items_staging_binary: moving it into the
+-- same transaction as the item write prevents an intervening tightener from replacing it with an old exact
+-- count. The flush also revalidates the envelope and holds the partition lock through commit.
 CREATE OR REPLACE FUNCTION prepare_partition_for_load(
     _collection text,
     _dt_lo timestamptz, _dt_hi timestamptz,
@@ -131,11 +131,6 @@ BEGIN
     );
     SELECT COALESCE(n, 0) INTO pre_load_n
         FROM pgstac.partition_stats WHERE partition = partition_name;
-    -- Over-estimating n is the safe direction; the async tightener computes the exact count + extent off the
-    -- hot path. Single-row atomic UPDATE, so concurrent loads into the same partition serialize on the row.
-    UPDATE pgstac.partition_stats
-        SET n = COALESCE(n, 0) + _n_add, dirty = true, last_updated = now()
-        WHERE partition = partition_name;
 END;
 $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
@@ -156,8 +151,11 @@ $$ LANGUAGE PLPGSQL SECURITY DEFINER;
 
 
 -- flush_items_staging_binary: move fully-dehydrated rows from a TEMP staging table into `items` with the
--- conflict policy. partition_stats (extent + n + dirty) is set entirely by prepare_partition_for_load in
--- the preflight, so this writes only `items`:
+-- conflict policy. Before touching items, aggregate the staged partitions, re-check/widen their metadata,
+-- and raise n while holding each partition advisory lock through commit. This closes the transaction gap
+-- between prepare_partition_for_load and flush: a tightener may run during COPY, but cannot run after this
+-- recheck and before the items become visible. Locks are acquired in the same collection/window order as
+-- ensure_partitions and the SQL staging path:
 --        ignore  -> ON CONFLICT DO NOTHING (idempotent; orphans the old row on a cross-partition move)
 --        upsert  -> delete a changed row IN THE PARTITION IT ROUTES TO (window-pruned), then insert. A
 --                   datetime change that stays in the partition is applied; one that moves the item to a
@@ -171,7 +169,56 @@ CREATE OR REPLACE FUNCTION flush_items_staging_binary(
 ) RETURNS bigint AS $$
 DECLARE
     nrows bigint;
+    _partition text;
+    _collection text;
+    _dtrange tstzrange;
+    _edtrange tstzrange;
+    _spatial geometry;
+    _staged_n bigint;
 BEGIN
+    FOR _collection, _dtrange, _edtrange, _spatial, _staged_n IN EXECUTE format(
+        $q$
+            WITH grouped AS (
+                SELECT
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    ) AS window_start,
+                    tstzrange(min(s.datetime), max(s.datetime), '[]') AS dtrange,
+                    tstzrange(min(s.end_datetime), max(s.end_datetime), '[]') AS edtrange,
+                    ST_SetSRID(ST_Extent(s.geometry)::geometry, 4326) AS spatial,
+                    count(*)::bigint AS staged_n
+                FROM %I s
+                JOIN pgstac.collections c ON c.id = s.collection
+                GROUP BY
+                    s.collection,
+                    COALESCE(
+                        date_trunc(c.partition_trunc::text, s.datetime),
+                        '-infinity'::timestamptz
+                    )
+            )
+            SELECT collection, dtrange, edtrange, spatial, staged_n
+            FROM grouped
+            ORDER BY collection, window_start
+        $q$,
+        _staging
+    ) LOOP
+        _partition := pgstac.check_partition(
+            _collection,
+            _dtrange,
+            _edtrange,
+            _spatial
+        );
+
+        -- Over-counting is safe for ignore/upsert conflicts; the deferred tightener restores exact n.
+        UPDATE pgstac.partition_stats
+        SET n = COALESCE(n, 0) + _staged_n,
+            dirty = true,
+            last_updated = now()
+        WHERE partition = _partition;
+    END LOOP;
+
     IF _policy = 'ignore' THEN
         EXECUTE format('INSERT INTO items SELECT * FROM %1$I ON CONFLICT DO NOTHING', _staging);
     ELSIF _policy = 'error' THEN

--- a/src/pgstac/sql/997_maintenance.sql
+++ b/src/pgstac/sql/997_maintenance.sql
@@ -1,8 +1,10 @@
 
--- tighten_dirty_partition_stats: recompute the exact envelope + row count for dirty partitions (oldest
--- first), clearing dirty. Run off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only
--- over-includes a partition in search, so skipping it never loses rows. `_limit` caps the batch (NULL =
--- all dirty); returns the number of partitions tightened.
+-- tighten_dirty_partition_stats: recompute the exact envelope + row count for partitions widened by
+-- ingest or queued by DELETE. Choose the oldest `_limit` candidates, then acquire their advisory locks in
+-- collection/partition order so concurrent multi-partition ingest follows the same lock order. Run
+-- off-hours (pg_cron or the maintenance CLI). Optional: a wide envelope only over-includes a partition in
+-- search, so skipping it never loses rows. `_limit` caps the batch (NULL = all pending); returns the number
+-- of partitions tightened.
 --
 -- pg_cron example (operators install this themselves):
 --   SELECT cron.schedule('pgstac-tighten', '*/15 * * * *',
@@ -14,10 +16,21 @@ DECLARE
     _count int := 0;
 BEGIN
     FOR _part IN
-        SELECT partition FROM pgstac.partition_stats
-        WHERE dirty
-        ORDER BY last_updated NULLS FIRST
-        LIMIT _limit
+        SELECT candidate.partition
+        FROM (
+            SELECT ps.partition, ps.collection
+            FROM pgstac.partition_stats ps
+            WHERE
+                ps.dirty
+                OR EXISTS (
+                    SELECT 1
+                    FROM pgstac.partition_stats_delete_queue q
+                    WHERE q.partition = ps.partition
+                )
+            ORDER BY ps.last_updated NULLS FIRST
+            LIMIT _limit
+        ) candidate
+        ORDER BY candidate.collection, candidate.partition
     LOOP
         PERFORM pgstac.tighten_partition_stats(_part);
         _count := _count + 1;
@@ -407,6 +420,12 @@ BEGIN
     -- extent would be left uncovered (search would prune + miss it). Same lock check_partition uses, so
     -- tighten serializes with ingest into this partition only.
     PERFORM pg_advisory_xact_lock(hashtext('pgstac.check_partition'), hashtext(_partition));
+
+    -- Acknowledge only DELETE work visible before the exact scan. Each concurrent DELETE appends an
+    -- independent row, so one that commits after this statement remains pending for the next sweep. If
+    -- the scan or stats write fails, this DELETE rolls back with the rest of the transaction.
+    DELETE FROM partition_stats_delete_queue
+    WHERE partition = _partition;
 
     EXECUTE format(
         $q$

--- a/src/pgstac/sql/998_idempotent_post.sql
+++ b/src/pgstac/sql/998_idempotent_post.sql
@@ -157,7 +157,12 @@ GRANT USAGE ON ALL SEQUENCES IN SCHEMA pgstac to pgstac_ingest;
 -- envelope-narrowing direct write structurally impossible. New partitions are created SELECT-only for
 -- pgstac_ingest by check_partition; the items parent is revoked here. Staging tables (items_staging*) stay
 -- writable so the SQL-only ingest path can COPY into them.
-REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON items, partition_stats, item_fragments FROM pgstac_ingest;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON
+    items,
+    partition_stats,
+    partition_stats_delete_queue,
+    item_fragments
+FROM pgstac_ingest;
 -- item_field_registry is the one exception to the wall: the loader WIDENS it directly with an add-only
 -- INSERT ... ON CONFLICT DO UPDATE (no SD function), so INSERT + UPDATE stay granted. DELETE/TRUNCATE remain
 -- revoked, so even a direct write cannot NARROW the registry — INV-1 (registry is a superset of the data)

--- a/src/pgstac/tests/pgtap.sql
+++ b/src/pgstac/tests/pgtap.sql
@@ -17,7 +17,9 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 SET SEARCH_PATH TO pgstac, pgtap, public;
 
 -- Plan the tests.
-SELECT plan(371);
+-- The upstream count was six high; this branch adds five assertions and
+-- corrects the stale plan so pg_prove sees a complete 370-test run.
+SELECT plan(370);
 --SELECT * FROM no_plan();
 
 -- Run the tests.

--- a/src/pgstac/tests/pgtap/000_privileges.sql
+++ b/src/pgstac/tests/pgtap/000_privileges.sql
@@ -20,3 +20,12 @@ SELECT ok(
     NOT has_table_privilege('pgstac_ingest', 'pgstac.item_fragments', 'DELETE'),
     'pgstac_ingest may not directly DELETE item_fragments (privilege wall)'
 );
+
+SELECT ok(
+    NOT has_table_privilege(
+        'pgstac_ingest',
+        'pgstac.partition_stats_delete_queue',
+        'INSERT'
+    ),
+    'pgstac_ingest may not directly enqueue partition-stat DELETE work (privilege wall)'
+);

--- a/src/pgstac/tests/pgtap/003_items.sql
+++ b/src/pgstac/tests/pgtap/003_items.sql
@@ -861,3 +861,201 @@ SELECT results_eq(
 );
 
 SELECT delete_item('pgstac-test-range-datetime', 'pgstac-test-collection');
+
+-- Partition statistics must stay conservative on the latency-sensitive SQL
+-- write path. After an exact tighten, items_staging does not provide a batch
+-- spatial envelope, so a later write must invalidate the exact extent rather
+-- than leave a too-small bound that partition_bounds() can prune.
+INSERT INTO collections (content)
+VALUES ('{"id":"pgstac-test-partition-stats-write"}'::jsonb)
+ON CONFLICT DO NOTHING;
+
+SELECT create_item('{
+  "id": "pgstac-test-partition-stats-base",
+  "collection": "pgstac-test-partition-stats-write",
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "geometry": {"type": "Point", "coordinates": [0, 0]},
+  "bbox": [0, 0, 0, 0],
+  "links": [], "assets": {},
+  "properties": {"datetime": "2020-01-01T00:00:00Z"}
+}'::jsonb);
+
+SELECT tighten_partition_stats((
+    SELECT partition FROM partition_sys_meta
+    WHERE collection = 'pgstac-test-partition-stats-write'
+));
+
+SELECT create_item('{
+  "id": "pgstac-test-partition-stats-east",
+  "collection": "pgstac-test-partition-stats-write",
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "geometry": {"type": "Point", "coordinates": [40, 10]},
+  "bbox": [40, 10, 40, 10],
+  "links": [], "assets": {},
+  "properties": {"datetime": "2020-01-01T00:00:00Z"}
+}'::jsonb);
+
+SELECT ok(
+    (SELECT spatial IS NULL FROM partition_stats
+     WHERE collection = 'pgstac-test-partition-stats-write'),
+    'SQL insert invalidates an exact spatial bound when the batch extent is unknown'
+);
+
+SELECT tighten_partition_stats((
+    SELECT partition FROM partition_sys_meta
+    WHERE collection = 'pgstac-test-partition-stats-write'
+));
+
+SELECT update_item('{
+  "id": "pgstac-test-partition-stats-base",
+  "collection": "pgstac-test-partition-stats-write",
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "geometry": {"type": "Point", "coordinates": [-40, -10]},
+  "bbox": [-40, -10, -40, -10],
+  "links": [], "assets": {},
+  "properties": {"datetime": "2020-01-01T00:00:00Z"}
+}'::jsonb);
+
+SELECT ok(
+    (SELECT spatial IS NULL FROM partition_stats
+     WHERE collection = 'pgstac-test-partition-stats-write'),
+    'SQL update invalidates an exact spatial bound when the batch extent is unknown'
+);
+
+SELECT delete_collection('pgstac-test-partition-stats-write');
+
+-- DELETE only narrows an envelope, so it can remain off the synchronous stats
+-- path. It must still make the partition discoverable by deferred maintenance,
+-- including when the last item is removed.
+INSERT INTO collections (content)
+VALUES ('{"id":"pgstac-test-partition-stats-delete"}'::jsonb)
+ON CONFLICT DO NOTHING;
+
+SELECT create_item('{
+  "id": "pgstac-test-partition-stats-delete-only",
+  "collection": "pgstac-test-partition-stats-delete",
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "geometry": {"type": "Point", "coordinates": [1, 1]},
+  "bbox": [1, 1, 1, 1],
+  "links": [], "assets": {},
+  "properties": {"datetime": "2024-01-01T00:00:00Z"}
+}'::jsonb);
+
+SELECT tighten_partition_stats((
+    SELECT partition FROM partition_sys_meta
+    WHERE collection = 'pgstac-test-partition-stats-delete'
+));
+SELECT delete_item(
+    'pgstac-test-partition-stats-delete-only',
+    'pgstac-test-partition-stats-delete'
+);
+SELECT tighten_dirty_partition_stats(NULL);
+
+SELECT ok(
+    (
+        SELECT
+            n = 0
+            AND isempty(dtrange)
+            AND isempty(edtrange)
+            AND spatial IS NULL
+            AND NOT dirty
+            AND NOT EXISTS (
+                SELECT 1
+                FROM partition_stats_delete_queue q
+                WHERE q.partition = ps.partition
+            )
+        FROM partition_stats ps
+        WHERE ps.collection = 'pgstac-test-partition-stats-delete'
+    ),
+    'deferred tightening makes last-item DELETE partition statistics exact'
+);
+
+SELECT delete_collection('pgstac-test-partition-stats-delete');
+
+-- The Rust loader commits prepare_partition_for_load before its later
+-- binary-COPY/flush transaction. Reproduce a tightener in that window: flush
+-- must re-establish conservative metadata in its own transaction.
+INSERT INTO collections (content)
+VALUES ('{"id":"pgstac-test-partition-stats-flush"}'::jsonb)
+ON CONFLICT DO NOTHING;
+
+SELECT create_item('{
+  "id": "pgstac-test-partition-stats-flush-base",
+  "collection": "pgstac-test-partition-stats-flush",
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "geometry": {"type": "Point", "coordinates": [0, 0]},
+  "bbox": [0, 0, 0, 0],
+  "links": [], "assets": {},
+  "properties": {"datetime": "2020-01-01T00:00:00Z"}
+}'::jsonb);
+
+SELECT tighten_partition_stats((
+    SELECT partition FROM partition_sys_meta
+    WHERE collection = 'pgstac-test-partition-stats-flush'
+));
+
+SELECT * FROM prepare_partition_for_load(
+    'pgstac-test-partition-stats-flush',
+    '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z',
+    '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z',
+    40, 10, 40, 10,
+    1
+);
+
+SELECT tighten_partition_stats((
+    SELECT partition FROM partition_sys_meta
+    WHERE collection = 'pgstac-test-partition-stats-flush'
+));
+
+DO $$
+DECLARE
+    staging_table text;
+    outside_item jsonb := '{
+      "id": "pgstac-test-partition-stats-flush-outside",
+      "collection": "pgstac-test-partition-stats-flush",
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "geometry": {"type": "Point", "coordinates": [40, 10]},
+      "bbox": [40, 10, 40, 10],
+      "links": [], "assets": {},
+      "properties": {"datetime": "2025-01-01T00:00:00Z"}
+    }'::jsonb;
+BEGIN
+    staging_table := make_binary_staging();
+    EXECUTE format(
+        'INSERT INTO %I SELECT * FROM items_staging_dehydrate(ARRAY[$1])',
+        staging_table
+    ) USING outside_item;
+    PERFORM flush_items_staging_binary(staging_table, 'error');
+END;
+$$;
+
+SELECT ok(
+    (
+        SELECT
+            ps.dirty
+            AND ps.n >= actual.n
+            AND ps.dtrange @> actual.dtrange
+            AND ps.edtrange @> actual.edtrange
+            AND (ps.spatial IS NULL OR ST_Covers(ps.spatial, actual.spatial))
+        FROM partition_stats ps
+        CROSS JOIN LATERAL (
+            SELECT
+                count(*) AS n,
+                tstzrange(min(datetime), max(datetime), '[]') AS dtrange,
+                tstzrange(min(end_datetime), max(end_datetime), '[]') AS edtrange,
+                ST_SetSRID(ST_Extent(geometry)::geometry, 4326) AS spatial
+            FROM items
+            WHERE collection = 'pgstac-test-partition-stats-flush'
+        ) actual
+        WHERE ps.collection = 'pgstac-test-partition-stats-flush'
+    ),
+    'binary flush re-establishes conservative stats after intervening tightening'
+);
+
+SELECT delete_collection('pgstac-test-partition-stats-flush');


### PR DESCRIPTION
Current main avoids the synchronous per-write ANALYZE introduced in
v0.9.11 by conservatively widening partition statistics during writes and
tightening them later.

While validating issue #471, I found correctness gaps in that newer
architecture:

1. SQL INSERT/UPDATE batches do not always provide an incoming spatial
   extent. After an exact tightening, an item outside the previous extent
   could leave a non-NULL spatial bound that was too small. Partition
   pruning could then exclude a partition containing a matching item.

2. DELETE could leave exact counts, temporal ranges, and spatial extents
   stale while dirty = false, meaning dirty-only maintenance would never
   revisit that partition.

3. The Rust bulk loader prepares partitions before its COPY/flush
   transaction. Maintenance could tighten a partition between preparation
   and flush, allowing the later rows to commit without restoring
   conservative statistics.

## Changes

- Invalidate an exact spatial bound when SQL staging cannot provide an
  incoming extent. A NULL spatial bound is conservative and prevents unsafe
  partition pruning until deferred tightening recomputes it.

- Record deleted partitions in a durable maintenance queue. The DELETE path
  remains cheap and avoids acquiring partition advisory locks after item-row
  locks, which would introduce lock-order inversion.

- Include queued DELETE partitions in deferred statistics tightening and
  consume queue entries transactionally with the exact partition scan.

- Recalculate staged temporal ranges, spatial extent, and count inside the
  bulk-flush transaction.

- Acquire partition locks in deterministic order for multi-partition batches.

- Regenerate the unreleased installation and migration SQL from the source
  fragments.

## Correctness coverage

Regression tests cover:

- tighten, then INSERT outside the previous spatial extent;
- tighten, then UPDATE outside the previous spatial extent;
- delete the final item, run deferred maintenance, and verify empty exact
  statistics;

- prepare a bulk load, tighten in the intervening window, then flush and
  verify that statistics conservatively cover the committed rows;

- privileges on the DELETE maintenance queue.

## Performance

This change does not reintroduce synchronous ANALYZE.

Local Podman benchmark results:

 Operation                     main                patched             Difference
━━━━━─────  ━━━━━━  ━━━━━─ ━━━━━━━───
 30k-row binary flush    206.441 ms    227.234 ms    +20.793 ms (+10.1%)
──────────  ──────  ──────  ──────────
 Single DELETE             0.026 ms      0.035 ms              +0.009 ms

The bulk-loader overhead is one set-based scan of the staging table, rather
than a full ANALYZE of the destination partition. DELETE only appends a
small indexed queue row; exact recomputation remains deferred.

The primary gain is correctness:

- no false-negative spatial pruning after an out-of-extent write;
- DELETE statistics eventually become exact;
- bulk rows and conservative metadata become visible atomically;
- current main's deferred-maintenance performance architecture is preserved.

## Relation to #471

Current main already removes the original synchronous-ANALYZE write latency
reported in #471. This PR closes correctness gaps found while verifying that
replacement architecture; it does not revert to per-write analysis.

## Validation

Passed:

- formatting, Ruff, and type checks;
- 370 PgTAP assertions;
- all basic SQL fixtures;
- pg_dump/pg_restore round trip;
- full Rust test suite and doctests;
- opt-in concurrent writers against real PostgreSQL;
- a two-session DELETE/tightening handoff test.

scripts/test --migrations currently encounters an existing upstream
migration-chain failure before reaching this patch:
where_stats(text,boolean,jsonb) still depends on search_wheres when the
older table is dropped. The same failure reproduces without this branch, so
that unrelated migration-history repair is intentionally not included here.

### How to test

Podman is sufficient; Colima is not required. With your existing Docker-compatible Podman setup:

scripts/test --pgtap --basicsql
scripts/test --rust
scripts/test --pgdump

Or run the complete default gate:

scripts/test

Optional real concurrent-writer coverage:

PGSTAC_TEST_DSN=postgresql://username:password@localhost:5439/pgstac_rs_test_rich \
cargo test --manifest-path src/pgstac-rs/Cargo.toml \
  --features cli \
  --test concurrency concurrent_writers \
  -- --nocapture

The project wrappers currently spell the backend command as docker compose; using Podman’s Docker-compatibility layer is enough.
---

## Checklist
- [x] **Linting:** Code is formatted and linted
- [x] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [x] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [ ] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [ ] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
- [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://stac-utils.github.io/ai-contribution-policy). Use of AI tools *must* be indicated.
---
> **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.