### PR TITLE
fix(docker): backport Trixie PostgreSQL base to v0.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Update the PostgreSQL container base from Debian Bullseye to Trixie so downstream
+  images can install additional packages from supported Debian repositories.
+
 
 ## [v0.9.12]
 

--- a/docker/pgstac/Dockerfile
+++ b/docker/pgstac/Dockerfile
@@ -2,7 +2,7 @@ ARG PG_MAJOR=17
 ARG POSTGIS_MAJOR=3
 
 # Base postgres image that pgstac can be installed onto
-FROM postgres:${PG_MAJOR}-bullseye AS pgstacbase
+FROM postgres:${PG_MAJOR}-trixie AS pgstacbase
 ARG POSTGIS_MAJOR
 ARG PG_MAJOR
 RUN  \


### PR DESCRIPTION
## Summary

Backport the supported Debian Trixie PostgreSQL base image to the v0.9.x release line.

The published v0.9.x image uses Bullseye, whose expired security repository metadata causes fresh downstream builds to fail during `apt-get update`. This blocks downstream images that install PostgreSQL extensions such as pgvector.

The same migration is already present on `main` as part of #427; this PR applies only the base-image update and changelog entry to `release_v0.9.12`.

Fixes #481.

## Validation

- Clean `pgstac` target build passed with `--pull --no-cache`.
- Database initialized and `pgstac.get_version()` returned `0.9.12`.
- Downstream `apt-get update` passed.
- `postgresql-17-pgvector` installed successfully from the Trixie PGDG repository.